### PR TITLE
Added data for win-loss records for seasons 2018 - 2023

### DIFF
--- a/datasets/win-loss-score-2018-season.csv
+++ b/datasets/win-loss-score-2018-season.csv
@@ -1,0 +1,257 @@
+Week,Day,Date,Time,Winner/tie,,Loser/tie,,PtsW,PtsL,YdsW,TOW,YdsL,TOL
+1,Thu,2018-09-06,8:20PM,Philadelphia Eagles,,Atlanta Falcons,boxscore,18,12,232,2,299,1
+1,Sun,2018-09-09,1:00PM,Baltimore Ravens,,Buffalo Bills,boxscore,47,3,369,1,153,2
+1,Sun,2018-09-09,1:00PM,Cincinnati Bengals,@,Indianapolis Colts,boxscore,34,23,330,2,380,2
+1,Sun,2018-09-09,1:00PM,Pittsburgh Steelers,@,Cleveland Browns,boxscore,21,21,472,6,327,1
+1,Sun,2018-09-09,1:00PM,New England Patriots,,Houston Texans,boxscore,27,20,389,3,325,2
+1,Sun,2018-09-09,1:00PM,Jacksonville Jaguars,@,New York Giants,boxscore,20,15,305,1,324,2
+1,Sun,2018-09-09,1:00PM,Miami Dolphins,,Tennessee Titans,boxscore,27,20,342,2,336,3
+1,Sun,2018-09-09,1:00PM,Minnesota Vikings,,San Francisco 49ers,boxscore,24,16,343,1,327,4
+1,Sun,2018-09-09,1:00PM,Tampa Bay Buccaneers,@,New Orleans Saints,boxscore,48,40,529,0,475,2
+1,Sun,2018-09-09,4:05PM,Kansas City Chiefs,@,Los Angeles Chargers,boxscore,38,28,362,0,541,2
+1,Sun,2018-09-09,4:25PM,Carolina Panthers,,Dallas Cowboys,boxscore,16,8,293,1,232,1
+1,Sun,2018-09-09,4:25PM,Washington Redskins,@,Arizona Cardinals,boxscore,24,6,429,1,213,2
+1,Sun,2018-09-09,4:25PM,Denver Broncos,,Seattle Seahawks,boxscore,27,24,470,3,306,3
+1,Sun,2018-09-09,8:20PM,Green Bay Packers,,Chicago Bears,boxscore,24,23,370,2,294,1
+1,Mon,2018-09-10,7:10PM,New York Jets,@,Detroit Lions,boxscore,48,17,349,2,339,5
+1,Mon,2018-09-10,10:20PM,Los Angeles Rams,@,Oakland Raiders,boxscore,33,13,365,0,395,3
+2,Thu,2018-09-13,8:20PM,Cincinnati Bengals,,Baltimore Ravens,boxscore,34,23,373,0,425,3
+2,Sun,2018-09-16,1:00PM,Atlanta Falcons,,Carolina Panthers,boxscore,31,24,442,1,439,1
+2,Sun,2018-09-16,1:00PM,Los Angeles Chargers,@,Buffalo Bills,boxscore,31,20,349,0,293,2
+2,Sun,2018-09-16,1:00PM,New Orleans Saints,,Cleveland Browns,boxscore,21,18,275,2,327,1
+2,Sun,2018-09-16,1:00PM,Indianapolis Colts,@,Washington Redskins,boxscore,21,9,281,2,334,1
+2,Sun,2018-09-16,1:00PM,Minnesota Vikings,@,Green Bay Packers,boxscore,29,29,480,1,351,0
+2,Sun,2018-09-16,1:00PM,Tennessee Titans,,Houston Texans,boxscore,20,17,283,0,437,1
+2,Sun,2018-09-16,1:00PM,Kansas City Chiefs,@,Pittsburgh Steelers,boxscore,42,37,449,1,475,0
+2,Sun,2018-09-16,1:00PM,Miami Dolphins,@,New York Jets,boxscore,20,12,257,2,362,3
+2,Sun,2018-09-16,1:00PM,Tampa Bay Buccaneers,,Philadelphia Eagles,boxscore,27,21,436,2,412,2
+2,Sun,2018-09-16,4:05PM,Los Angeles Rams,,Arizona Cardinals,boxscore,34,0,432,1,137,1
+2,Sun,2018-09-16,4:05PM,San Francisco 49ers,,Detroit Lions,boxscore,30,27,346,0,427,1
+2,Sun,2018-09-16,4:25PM,Denver Broncos,,Oakland Raiders,boxscore,20,19,385,1,373,0
+2,Sun,2018-09-16,4:25PM,Jacksonville Jaguars,,New England Patriots,boxscore,31,20,480,2,302,1
+2,Sun,2018-09-16,8:20PM,Dallas Cowboys,,New York Giants,boxscore,20,13,298,0,255,1
+2,Mon,2018-09-17,8:15PM,Chicago Bears,,Seattle Seahawks,boxscore,24,17,271,2,276,2
+3,Thu,2018-09-20,8:20PM,Cleveland Browns,,New York Jets,boxscore,21,17,323,0,268,3
+3,Sun,2018-09-23,1:00PM,New Orleans Saints,@,Atlanta Falcons,boxscore,43,37,534,0,407,0
+3,Sun,2018-09-23,1:00PM,Buffalo Bills,@,Minnesota Vikings,boxscore,27,6,292,0,292,3
+3,Sun,2018-09-23,1:00PM,Carolina Panthers,,Cincinnati Bengals,boxscore,31,21,377,0,396,4
+3,Sun,2018-09-23,1:00PM,Philadelphia Eagles,,Indianapolis Colts,boxscore,20,16,379,2,209,0
+3,Sun,2018-09-23,1:00PM,Baltimore Ravens,,Denver Broncos,boxscore,27,14,342,0,293,1
+3,Sun,2018-09-23,1:00PM,Washington Redskins,,Green Bay Packers,boxscore,31,17,386,1,340,1
+3,Sun,2018-09-23,1:00PM,New York Giants,@,Houston Texans,boxscore,27,22,379,0,427,2
+3,Sun,2018-09-23,1:00PM,Tennessee Titans,@,Jacksonville Jaguars,boxscore,9,6,233,0,232,1
+3,Sun,2018-09-23,1:00PM,Kansas City Chiefs,,San Francisco 49ers,boxscore,38,27,384,0,406,0
+3,Sun,2018-09-23,1:00PM,Miami Dolphins,,Oakland Raiders,boxscore,28,20,373,0,434,2
+3,Sun,2018-09-23,4:05PM,Los Angeles Rams,,Los Angeles Chargers,boxscore,35,23,521,2,356,2
+3,Sun,2018-09-23,4:25PM,Chicago Bears,@,Arizona Cardinals,boxscore,16,14,316,2,221,4
+3,Sun,2018-09-23,4:25PM,Seattle Seahawks,,Dallas Cowboys,boxscore,24,13,295,0,303,3
+3,Sun,2018-09-23,8:20PM,Detroit Lions,,New England Patriots,boxscore,26,10,414,1,209,1
+3,Mon,2018-09-24,8:15PM,Pittsburgh Steelers,@,Tampa Bay Buccaneers,boxscore,30,27,413,1,455,4
+4,Thu,2018-09-27,8:20PM,Los Angeles Rams,,Minnesota Vikings,boxscore,38,31,556,0,446,1
+4,Sun,2018-09-30,1:00PM,Cincinnati Bengals,@,Atlanta Falcons,boxscore,37,36,407,1,495,0
+4,Sun,2018-09-30,1:00PM,Green Bay Packers,,Buffalo Bills,boxscore,22,0,423,2,145,3
+4,Sun,2018-09-30,1:00PM,Chicago Bears,,Tampa Bay Buccaneers,boxscore,48,10,483,0,311,3
+4,Sun,2018-09-30,1:00PM,Houston Texans,@,Indianapolis Colts,boxscore,37,34,466,1,478,2
+4,Sun,2018-09-30,1:00PM,Dallas Cowboys,,Detroit Lions,boxscore,26,24,414,0,382,0
+4,Sun,2018-09-30,1:00PM,Jacksonville Jaguars,,New York Jets,boxscore,31,12,503,3,178,0
+4,Sun,2018-09-30,1:00PM,New England Patriots,,Miami Dolphins,boxscore,38,7,449,2,172,2
+4,Sun,2018-09-30,1:00PM,Tennessee Titans,,Philadelphia Eagles,boxscore,26,23,397,1,432,1
+4,Sun,2018-09-30,4:05PM,Oakland Raiders,,Cleveland Browns,boxscore,45,42,565,2,487,4
+4,Sun,2018-09-30,4:05PM,Seattle Seahawks,@,Arizona Cardinals,boxscore,20,17,331,0,263,1
+4,Sun,2018-09-30,4:25PM,New Orleans Saints,@,New York Giants,boxscore,33,18,389,0,299,2
+4,Sun,2018-09-30,4:25PM,Los Angeles Chargers,,San Francisco 49ers,boxscore,29,27,368,1,364,2
+4,Sun,2018-09-30,8:20PM,Baltimore Ravens,@,Pittsburgh Steelers,boxscore,26,14,451,1,284,2
+4,Mon,2018-10-01,8:15PM,Kansas City Chiefs,@,Denver Broncos,boxscore,27,23,446,0,385,1
+5,Thu,2018-10-04,8:20PM,New England Patriots,,Indianapolis Colts,boxscore,38,24,438,2,439,3
+5,Sun,2018-10-07,1:00PM,Carolina Panthers,,New York Giants,boxscore,33,31,350,2,432,3
+5,Sun,2018-10-07,1:00PM,Pittsburgh Steelers,,Atlanta Falcons,boxscore,41,17,381,1,324,1
+5,Sun,2018-10-07,1:00PM,Buffalo Bills,,Tennessee Titans,boxscore,13,12,223,1,221,3
+5,Sun,2018-10-07,1:00PM,Cincinnati Bengals,,Miami Dolphins,boxscore,27,17,332,1,297,3
+5,Sun,2018-10-07,1:00PM,Cleveland Browns,,Baltimore Ravens,boxscore,12,9,416,1,410,2
+5,Sun,2018-10-07,1:00PM,New York Jets,,Denver Broncos,boxscore,34,16,512,2,436,1
+5,Sun,2018-10-07,1:00PM,Detroit Lions,,Green Bay Packers,boxscore,31,23,264,0,521,3
+5,Sun,2018-10-07,1:00PM,Kansas City Chiefs,,Jacksonville Jaguars,boxscore,30,14,424,2,502,5
+5,Sun,2018-10-07,4:05PM,Los Angeles Chargers,,Oakland Raiders,boxscore,26,10,412,0,289,2
+5,Sun,2018-10-07,4:25PM,Arizona Cardinals,@,San Francisco 49ers,boxscore,28,18,220,0,447,5
+5,Sun,2018-10-07,4:25PM,Minnesota Vikings,@,Philadelphia Eagles,boxscore,23,21,375,1,364,2
+5,Sun,2018-10-07,4:25PM,Los Angeles Rams,@,Seattle Seahawks,boxscore,33,31,468,2,373,0
+5,Sun,2018-10-07,8:20PM,Houston Texans,,Dallas Cowboys,boxscore,19,16,462,2,292,2
+5,Mon,2018-10-08,8:15PM,New Orleans Saints,,Washington Redskins,boxscore,43,19,447,1,283,2
+6,Thu,2018-10-11,8:20PM,Philadelphia Eagles,@,New York Giants,boxscore,34,13,379,0,401,1
+6,Sun,2018-10-14,1:00PM,Washington Redskins,,Carolina Panthers,boxscore,23,17,288,0,350,3
+6,Sun,2018-10-14,1:00PM,Miami Dolphins,,Chicago Bears,boxscore,31,28,541,3,467,3
+6,Sun,2018-10-14,1:00PM,Atlanta Falcons,,Tampa Bay Buccaneers,boxscore,34,29,417,0,510,2
+6,Sun,2018-10-14,1:00PM,Houston Texans,,Buffalo Bills,boxscore,20,13,216,3,229,3
+6,Sun,2018-10-14,1:00PM,Pittsburgh Steelers,@,Cincinnati Bengals,boxscore,28,21,481,0,275,0
+6,Sun,2018-10-14,1:00PM,Los Angeles Chargers,@,Cleveland Browns,boxscore,38,14,449,1,317,2
+6,Sun,2018-10-14,1:00PM,New York Jets,,Indianapolis Colts,boxscore,42,34,374,2,428,4
+6,Sun,2018-10-14,1:00PM,Minnesota Vikings,,Arizona Cardinals,boxscore,27,17,411,2,268,2
+6,Sun,2018-10-14,1:00PM,Seattle Seahawks,@,Oakland Raiders,boxscore,27,3,369,1,185,2
+6,Sun,2018-10-14,4:05PM,Los Angeles Rams,@,Denver Broncos,boxscore,23,20,444,1,357,1
+6,Sun,2018-10-14,4:25PM,Dallas Cowboys,,Jacksonville Jaguars,boxscore,40,7,378,0,204,2
+6,Sun,2018-10-14,4:25PM,Baltimore Ravens,@,Tennessee Titans,boxscore,21,0,361,1,106,0
+6,Sun,2018-10-14,8:20PM,New England Patriots,,Kansas City Chiefs,boxscore,43,40,500,1,446,2
+6,Mon,2018-10-15,8:15PM,Green Bay Packers,,San Francisco 49ers,boxscore,33,30,521,0,401,3
+7,Thu,2018-10-18,8:20PM,Denver Broncos,@,Arizona Cardinals,boxscore,45,10,309,1,223,5
+7,Sun,2018-10-21,9:30AM,Los Angeles Chargers,,Tennessee Titans,boxscore,20,19,344,0,390,1
+7,Sun,2018-10-21,1:00PM,Carolina Panthers,@,Philadelphia Eagles,boxscore,21,17,371,0,342,1
+7,Sun,2018-10-21,1:00PM,New England Patriots,@,Chicago Bears,boxscore,38,31,381,3,453,2
+7,Sun,2018-10-21,1:00PM,Detroit Lions,@,Miami Dolphins,boxscore,32,21,457,0,322,0
+7,Sun,2018-10-21,1:00PM,Indianapolis Colts,,Buffalo Bills,boxscore,37,5,376,0,303,5
+7,Sun,2018-10-21,1:00PM,Tampa Bay Buccaneers,,Cleveland Browns,boxscore,26,23,456,4,305,1
+7,Sun,2018-10-21,1:00PM,Houston Texans,@,Jacksonville Jaguars,boxscore,20,7,272,0,259,3
+7,Sun,2018-10-21,1:00PM,Minnesota Vikings,@,New York Jets,boxscore,37,17,316,0,263,4
+7,Sun,2018-10-21,4:05PM,New Orleans Saints,@,Baltimore Ravens,boxscore,24,23,339,1,351,0
+7,Sun,2018-10-21,4:25PM,Washington Redskins,,Dallas Cowboys,boxscore,20,17,305,0,323,2
+7,Sun,2018-10-21,4:25PM,Los Angeles Rams,@,San Francisco 49ers,boxscore,39,10,339,0,228,4
+7,Sun,2018-10-21,8:20PM,Kansas City Chiefs,,Cincinnati Bengals,boxscore,45,10,551,1,239,1
+7,Mon,2018-10-22,8:15PM,Atlanta Falcons,,New York Giants,boxscore,23,20,423,1,433,0
+8,Thu,2018-10-25,8:20PM,Houston Texans,,Miami Dolphins,boxscore,42,23,427,0,370,1
+8,Sun,2018-10-28,9:30AM,Philadelphia Eagles,@,Jacksonville Jaguars,boxscore,24,18,395,2,335,1
+8,Sun,2018-10-28,1:00PM,Carolina Panthers,,Baltimore Ravens,boxscore,36,21,386,0,325,3
+8,Sun,2018-10-28,1:00PM,Chicago Bears,,New York Jets,boxscore,24,10,395,0,207,0
+8,Sun,2018-10-28,1:00PM,Seattle Seahawks,@,Detroit Lions,boxscore,28,14,413,0,331,3
+8,Sun,2018-10-28,1:00PM,Cincinnati Bengals,,Tampa Bay Buccaneers,boxscore,37,34,402,0,576,4
+8,Sun,2018-10-28,1:00PM,Pittsburgh Steelers,,Cleveland Browns,boxscore,33,18,421,2,237,1
+8,Sun,2018-10-28,1:00PM,Kansas City Chiefs,,Denver Broncos,boxscore,30,23,340,1,411,2
+8,Sun,2018-10-28,1:00PM,Washington Redskins,@,New York Giants,boxscore,20,13,360,1,303,2
+8,Sun,2018-10-28,4:05PM,Indianapolis Colts,@,Oakland Raiders,boxscore,42,28,461,0,347,1
+8,Sun,2018-10-28,4:25PM,Los Angeles Rams,,Green Bay Packers,boxscore,29,27,416,0,359,1
+8,Sun,2018-10-28,4:25PM,Arizona Cardinals,,San Francisco 49ers,boxscore,18,15,321,2,267,0
+8,Sun,2018-10-28,8:20PM,New Orleans Saints,@,Minnesota Vikings,boxscore,30,20,270,1,423,2
+8,Mon,2018-10-29,8:15PM,New England Patriots,@,Buffalo Bills,boxscore,25,6,387,0,333,2
+9,Thu,2018-11-01,8:20PM,San Francisco 49ers,,Oakland Raiders,boxscore,34,3,405,0,242,0
+9,Sun,2018-11-04,1:00PM,Atlanta Falcons,@,Washington Redskins,boxscore,38,14,491,1,366,1
+9,Sun,2018-11-04,1:00PM,Carolina Panthers,,Tampa Bay Buccaneers,boxscore,42,28,407,0,301,2
+9,Sun,2018-11-04,1:00PM,Minnesota Vikings,,Detroit Lions,boxscore,24,9,283,2,209,1
+9,Sun,2018-11-04,1:00PM,Pittsburgh Steelers,@,Baltimore Ravens,boxscore,23,16,395,0,265,0
+9,Sun,2018-11-04,1:00PM,Chicago Bears,@,Buffalo Bills,boxscore,41,9,190,1,264,4
+9,Sun,2018-11-04,1:00PM,Kansas City Chiefs,@,Cleveland Browns,boxscore,37,21,499,1,388,1
+9,Sun,2018-11-04,1:00PM,Miami Dolphins,,New York Jets,boxscore,13,6,168,0,282,4
+9,Sun,2018-11-04,4:05PM,Los Angeles Chargers,@,Seattle Seahawks,boxscore,25,17,375,0,356,1
+9,Sun,2018-11-04,4:05PM,Houston Texans,@,Denver Broncos,boxscore,19,17,290,0,348,1
+9,Sun,2018-11-04,4:25PM,New Orleans Saints,,Los Angeles Rams,boxscore,45,35,487,1,483,1
+9,Sun,2018-11-04,8:20PM,New England Patriots,,Green Bay Packers,boxscore,31,17,433,0,367,1
+9,Mon,2018-11-05,8:15PM,Tennessee Titans,@,Dallas Cowboys,boxscore,28,14,340,2,297,2
+10,Thu,2018-11-08,8:20PM,Pittsburgh Steelers,,Carolina Panthers,boxscore,52,21,457,0,242,2
+10,Sun,2018-11-11,1:00PM,Cleveland Browns,,Atlanta Falcons,boxscore,28,16,427,1,382,2
+10,Sun,2018-11-11,1:00PM,Chicago Bears,,Detroit Lions,boxscore,34,22,402,0,305,3
+10,Sun,2018-11-11,1:00PM,New Orleans Saints,@,Cincinnati Bengals,boxscore,51,14,509,0,284,2
+10,Sun,2018-11-11,1:00PM,Indianapolis Colts,,Jacksonville Jaguars,boxscore,29,26,366,1,415,1
+10,Sun,2018-11-11,1:00PM,Kansas City Chiefs,,Arizona Cardinals,boxscore,26,14,330,0,260,2
+10,Sun,2018-11-11,1:00PM,Washington Redskins,@,Tampa Bay Buccaneers,boxscore,16,3,286,0,501,4
+10,Sun,2018-11-11,1:00PM,Buffalo Bills,@,New York Jets,boxscore,41,10,451,0,199,2
+10,Sun,2018-11-11,1:00PM,Tennessee Titans,,New England Patriots,boxscore,34,10,385,0,284,0
+10,Sun,2018-11-11,4:05PM,Los Angeles Chargers,@,Oakland Raiders,boxscore,20,6,335,1,317,1
+10,Sun,2018-11-11,4:25PM,Green Bay Packers,,Miami Dolphins,boxscore,31,12,377,1,294,2
+10,Sun,2018-11-11,4:25PM,Los Angeles Rams,,Seattle Seahawks,boxscore,36,31,456,0,414,1
+10,Sun,2018-11-11,8:20PM,Dallas Cowboys,@,Philadelphia Eagles,boxscore,27,20,410,0,421,1
+10,Mon,2018-11-12,8:15PM,New York Giants,@,San Francisco 49ers,boxscore,27,23,277,0,374,2
+11,Thu,2018-11-15,8:20PM,Seattle Seahawks,,Green Bay Packers,boxscore,27,24,378,1,359,0
+11,Sun,2018-11-18,1:00PM,Dallas Cowboys,@,Atlanta Falcons,boxscore,22,19,323,0,354,1
+11,Sun,2018-11-18,1:00PM,Detroit Lions,,Carolina Panthers,boxscore,20,19,309,0,387,1
+11,Sun,2018-11-18,1:00PM,Baltimore Ravens,,Cincinnati Bengals,boxscore,24,21,403,1,255,0
+11,Sun,2018-11-18,1:00PM,Indianapolis Colts,,Tennessee Titans,boxscore,38,10,397,0,267,2
+11,Sun,2018-11-18,1:00PM,Houston Texans,@,Washington Redskins,boxscore,23,21,320,3,278,2
+11,Sun,2018-11-18,1:00PM,Pittsburgh Steelers,@,Jacksonville Jaguars,boxscore,20,16,323,3,243,1
+11,Sun,2018-11-18,1:00PM,New York Giants,,Tampa Bay Buccaneers,boxscore,38,35,359,0,510,4
+11,Sun,2018-11-18,4:05PM,Oakland Raiders,@,Arizona Cardinals,boxscore,23,21,325,0,282,2
+11,Sun,2018-11-18,4:05PM,Denver Broncos,@,Los Angeles Chargers,boxscore,23,22,325,0,479,2
+11,Sun,2018-11-18,4:25PM,New Orleans Saints,,Philadelphia Eagles,boxscore,48,7,546,0,196,3
+11,Sun,2018-11-18,8:20PM,Chicago Bears,,Minnesota Vikings,boxscore,25,20,308,3,268,3
+11,Mon,2018-11-19,8:15PM,Los Angeles Rams,,Kansas City Chiefs,boxscore,54,51,455,2,546,5
+12,Thu,2018-11-22,12:30PM,Chicago Bears,@,Detroit Lions,boxscore,23,16,264,1,333,2
+12,Thu,2018-11-22,4:30PM,Dallas Cowboys,,Washington Redskins,boxscore,31,23,404,0,331,3
+12,Thu,2018-11-22,8:20PM,New Orleans Saints,,Atlanta Falcons,boxscore,31,17,312,1,366,4
+12,Sun,2018-11-25,1:00PM,Buffalo Bills,,Jacksonville Jaguars,boxscore,24,21,327,0,333,2
+12,Sun,2018-11-25,1:00PM,Seattle Seahawks,@,Carolina Panthers,boxscore,30,27,397,0,476,1
+12,Sun,2018-11-25,1:00PM,Cleveland Browns,@,Cincinnati Bengals,boxscore,35,20,342,0,372,2
+12,Sun,2018-11-25,1:00PM,New England Patriots,@,New York Jets,boxscore,27,13,498,0,338,1
+12,Sun,2018-11-25,1:00PM,Philadelphia Eagles,,New York Giants,boxscore,25,22,341,0,402,1
+12,Sun,2018-11-25,1:00PM,Baltimore Ravens,,Oakland Raiders,boxscore,34,17,416,2,249,1
+12,Sun,2018-11-25,1:00PM,Tampa Bay Buccaneers,,San Francisco 49ers,boxscore,27,9,412,0,342,2
+12,Sun,2018-11-25,4:05PM,Los Angeles Chargers,,Arizona Cardinals,boxscore,45,10,414,1,149,1
+12,Sun,2018-11-25,4:25PM,Indianapolis Colts,,Miami Dolphins,boxscore,27,24,455,3,314,1
+12,Sun,2018-11-25,4:25PM,Denver Broncos,,Pittsburgh Steelers,boxscore,24,17,308,0,527,4
+12,Sun,2018-11-25,8:20PM,Minnesota Vikings,,Green Bay Packers,boxscore,24,17,416,0,254,1
+12,Mon,2018-11-26,8:15PM,Houston Texans,,Tennessee Titans,boxscore,34,17,462,0,365,1
+13,Thu,2018-11-29,8:20PM,Dallas Cowboys,,New Orleans Saints,boxscore,13,10,308,2,176,1
+13,Sun,2018-12-02,1:00PM,Baltimore Ravens,@,Atlanta Falcons,boxscore,26,16,366,1,131,1
+13,Sun,2018-12-02,1:00PM,Miami Dolphins,,Buffalo Bills,boxscore,21,17,175,1,415,3
+13,Sun,2018-12-02,1:00PM,Tampa Bay Buccaneers,,Carolina Panthers,boxscore,24,17,315,1,444,4
+13,Sun,2018-12-02,1:00PM,New York Giants,,Chicago Bears,boxscore,30,27,338,1,376,3
+13,Sun,2018-12-02,1:00PM,Denver Broncos,@,Cincinnati Bengals,boxscore,24,10,361,1,313,3
+13,Sun,2018-12-02,1:00PM,Houston Texans,,Cleveland Browns,boxscore,29,13,384,0,428,4
+13,Sun,2018-12-02,1:00PM,Jacksonville Jaguars,,Indianapolis Colts,boxscore,6,0,211,1,265,2
+13,Sun,2018-12-02,1:00PM,Arizona Cardinals,@,Green Bay Packers,boxscore,20,17,315,0,325,0
+13,Sun,2018-12-02,1:00PM,Los Angeles Rams,@,Detroit Lions,boxscore,30,16,344,2,310,2
+13,Sun,2018-12-02,4:05PM,Kansas City Chiefs,@,Oakland Raiders,boxscore,40,33,469,1,442,3
+13,Sun,2018-12-02,4:05PM,Tennessee Titans,,New York Jets,boxscore,26,22,403,1,280,1
+13,Sun,2018-12-02,4:25PM,New England Patriots,,Minnesota Vikings,boxscore,24,10,471,1,278,2
+13,Sun,2018-12-02,4:25PM,Seattle Seahawks,,San Francisco 49ers,boxscore,43,16,331,0,452,3
+13,Sun,2018-12-02,8:20PM,Los Angeles Chargers,@,Pittsburgh Steelers,boxscore,33,30,371,0,336,1
+13,Mon,2018-12-03,8:15PM,Philadelphia Eagles,,Washington Redskins,boxscore,28,13,436,1,235,1
+14,Thu,2018-12-06,8:20PM,Tennessee Titans,,Jacksonville Jaguars,boxscore,30,9,426,1,255,1
+14,Sun,2018-12-09,1:00PM,Green Bay Packers,,Atlanta Falcons,boxscore,34,20,300,0,344,2
+14,Sun,2018-12-09,1:00PM,New York Jets,@,Buffalo Bills,boxscore,27,23,248,2,368,3
+14,Sun,2018-12-09,1:00PM,Cleveland Browns,,Carolina Panthers,boxscore,26,20,348,2,393,1
+14,Sun,2018-12-09,1:00PM,Indianapolis Colts,@,Houston Texans,boxscore,24,21,436,1,315,0
+14,Sun,2018-12-09,1:00PM,Kansas City Chiefs,,Baltimore Ravens,boxscore,27,24,442,1,321,1
+14,Sun,2018-12-09,1:00PM,Miami Dolphins,,New England Patriots,boxscore,34,33,412,0,421,0
+14,Sun,2018-12-09,1:00PM,New Orleans Saints,@,Tampa Bay Buccaneers,boxscore,28,14,298,2,279,1
+14,Sun,2018-12-09,1:00PM,New York Giants,@,Washington Redskins,boxscore,40,16,402,1,288,3
+14,Sun,2018-12-09,4:05PM,Los Angeles Chargers,,Cincinnati Bengals,boxscore,26,21,288,0,295,0
+14,Sun,2018-12-09,4:05PM,San Francisco 49ers,,Denver Broncos,boxscore,20,14,389,1,274,0
+14,Sun,2018-12-09,4:25PM,Detroit Lions,@,Arizona Cardinals,boxscore,17,3,218,1,279,1
+14,Sun,2018-12-09,4:25PM,Dallas Cowboys,,Philadelphia Eagles,boxscore,29,23,576,3,256,1
+14,Sun,2018-12-09,4:25PM,Oakland Raiders,,Pittsburgh Steelers,boxscore,24,21,354,1,340,1
+14,Sun,2018-12-09,8:20PM,Chicago Bears,,Los Angeles Rams,boxscore,15,6,294,3,214,4
+14,Mon,2018-12-10,8:15PM,Seattle Seahawks,,Minnesota Vikings,boxscore,21,7,274,1,276,1
+15,Thu,2018-12-13,8:20PM,Los Angeles Chargers,@,Kansas City Chiefs,boxscore,29,28,407,2,294,0
+15,Sat,2018-12-15,4:30PM,Houston Texans,@,New York Jets,boxscore,29,22,286,0,318,1
+15,Sat,2018-12-15,8:20PM,Cleveland Browns,@,Denver Broncos,boxscore,17,16,309,2,270,2
+15,Sun,2018-12-16,1:00PM,Atlanta Falcons,,Arizona Cardinals,boxscore,40,14,435,0,253,3
+15,Sun,2018-12-16,1:00PM,Buffalo Bills,,Detroit Lions,boxscore,14,13,312,0,313,0
+15,Sun,2018-12-16,1:00PM,Chicago Bears,,Green Bay Packers,boxscore,24,17,332,1,323,1
+15,Sun,2018-12-16,1:00PM,Cincinnati Bengals,,Oakland Raiders,boxscore,30,16,294,1,297,2
+15,Sun,2018-12-16,1:00PM,Indianapolis Colts,,Dallas Cowboys,boxscore,23,0,370,1,292,1
+15,Sun,2018-12-16,1:00PM,Washington Redskins,@,Jacksonville Jaguars,boxscore,16,13,245,0,192,2
+15,Sun,2018-12-16,1:00PM,Minnesota Vikings,,Miami Dolphins,boxscore,41,17,418,1,193,0
+15,Sun,2018-12-16,1:00PM,Tennessee Titans,@,New York Giants,boxscore,17,0,301,0,260,2
+15,Sun,2018-12-16,1:00PM,Baltimore Ravens,,Tampa Bay Buccaneers,boxscore,20,12,370,2,241,1
+15,Sun,2018-12-16,4:05PM,San Francisco 49ers,,Seattle Seahawks,boxscore,26,23,351,1,385,0
+15,Sun,2018-12-16,4:25PM,Pittsburgh Steelers,,New England Patriots,boxscore,17,10,376,2,368,1
+15,Sun,2018-12-16,8:20PM,Philadelphia Eagles,@,Los Angeles Rams,boxscore,30,23,381,1,407,3
+15,Mon,2018-12-17,8:15PM,New Orleans Saints,@,Carolina Panthers,boxscore,12,9,346,2,247,2
+16,Sat,2018-12-22,4:30PM,Tennessee Titans,,Washington Redskins,boxscore,25,16,291,0,292,2
+16,Sat,2018-12-22,8:20PM,Baltimore Ravens,@,Los Angeles Chargers,boxscore,22,10,361,1,198,3
+16,Sun,2018-12-23,1:00PM,Atlanta Falcons,@,Carolina Panthers,boxscore,24,10,427,2,436,4
+16,Sun,2018-12-23,1:00PM,New England Patriots,,Buffalo Bills,boxscore,24,12,390,3,289,3
+16,Sun,2018-12-23,1:00PM,Cleveland Browns,,Cincinnati Bengals,boxscore,26,18,493,0,209,0
+16,Sun,2018-12-23,1:00PM,Indianapolis Colts,,New York Giants,boxscore,28,27,402,1,392,1
+16,Sun,2018-12-23,1:00PM,Dallas Cowboys,,Tampa Bay Buccaneers,boxscore,27,20,232,0,383,2
+16,Sun,2018-12-23,1:00PM,Minnesota Vikings,@,Detroit Lions,boxscore,27,9,340,0,223,0
+16,Sun,2018-12-23,1:00PM,Green Bay Packers,@,New York Jets,boxscore,44,38,540,1,370,0
+16,Sun,2018-12-23,1:00PM,Philadelphia Eagles,,Houston Texans,boxscore,32,30,519,3,371,1
+16,Sun,2018-12-23,1:00PM,Jacksonville Jaguars,@,Miami Dolphins,boxscore,17,7,244,1,183,2
+16,Sun,2018-12-23,4:05PM,Chicago Bears,@,San Francisco 49ers,boxscore,14,9,325,2,279,1
+16,Sun,2018-12-23,4:05PM,Los Angeles Rams,@,Arizona Cardinals,boxscore,31,9,461,1,263,0
+16,Sun,2018-12-23,4:25PM,New Orleans Saints,,Pittsburgh Steelers,boxscore,31,28,370,1,429,2
+16,Sun,2018-12-23,8:20PM,Seattle Seahawks,,Kansas City Chiefs,boxscore,38,31,464,0,419,2
+16,Mon,2018-12-24,8:15PM,Oakland Raiders,,Denver Broncos,boxscore,27,14,273,0,300,2
+17,Sun,2018-12-30,1:00PM,Atlanta Falcons,@,Tampa Bay Buccaneers,boxscore,34,32,489,1,433,1
+17,Sun,2018-12-30,1:00PM,Buffalo Bills,,Miami Dolphins,boxscore,42,17,381,1,225,4
+17,Sun,2018-12-30,1:00PM,Carolina Panthers,@,New Orleans Saints,boxscore,33,14,374,0,294,1
+17,Sun,2018-12-30,1:00PM,Dallas Cowboys,@,New York Giants,boxscore,36,35,419,1,441,2
+17,Sun,2018-12-30,1:00PM,Detroit Lions,@,Green Bay Packers,boxscore,31,0,402,0,175,1
+17,Sun,2018-12-30,1:00PM,Houston Texans,,Jacksonville Jaguars,boxscore,20,3,342,1,119,2
+17,Sun,2018-12-30,1:00PM,New England Patriots,,New York Jets,boxscore,38,3,375,0,239,3
+17,Sun,2018-12-30,4:25PM,Chicago Bears,@,Minnesota Vikings,boxscore,24,10,332,0,164,0
+17,Sun,2018-12-30,4:25PM,Pittsburgh Steelers,,Cincinnati Bengals,boxscore,16,13,343,1,196,0
+17,Sun,2018-12-30,4:25PM,Baltimore Ravens,,Cleveland Browns,boxscore,26,24,463,1,426,3
+17,Sun,2018-12-30,4:25PM,Seattle Seahawks,,Arizona Cardinals,boxscore,27,24,291,1,198,2
+17,Sun,2018-12-30,4:25PM,Los Angeles Chargers,@,Denver Broncos,boxscore,23,9,276,4,370,4
+17,Sun,2018-12-30,4:25PM,Kansas City Chiefs,,Oakland Raiders,boxscore,35,3,409,1,292,4
+17,Sun,2018-12-30,4:25PM,Philadelphia Eagles,@,Washington Redskins,boxscore,24,0,360,1,89,1
+17,Sun,2018-12-30,4:25PM,Los Angeles Rams,,San Francisco 49ers,boxscore,48,32,377,0,391,4
+17,Sun,2018-12-30,8:20PM,Indianapolis Colts,@,Tennessee Titans,boxscore,33,17,436,2,258,3

--- a/datasets/win-loss-score-2019-season.csv
+++ b/datasets/win-loss-score-2019-season.csv
@@ -1,0 +1,257 @@
+Week,Day,Date,Time,Winner/tie,,Loser/tie,,PtsW,PtsL,YdsW,TOW,YdsL,TOL
+1,Thu,2019-09-05,8:20PM,Green Bay Packers,@,Chicago Bears,boxscore,10,3,213,0,254,1
+1,Sun,2019-09-08,1:00PM,Minnesota Vikings,,Atlanta Falcons,boxscore,28,12,269,0,345,3
+1,Sun,2019-09-08,1:00PM,Buffalo Bills,@,New York Jets,boxscore,17,16,370,4,223,1
+1,Sun,2019-09-08,1:00PM,Los Angeles Rams,@,Carolina Panthers,boxscore,30,27,349,1,343,3
+1,Sun,2019-09-08,1:00PM,Tennessee Titans,@,Cleveland Browns,boxscore,43,13,339,0,346,3
+1,Sun,2019-09-08,1:00PM,Kansas City Chiefs,@,Jacksonville Jaguars,boxscore,40,26,491,0,428,2
+1,Sun,2019-09-08,1:00PM,Baltimore Ravens,@,Miami Dolphins,boxscore,59,10,643,0,200,3
+1,Sun,2019-09-08,1:00PM,Philadelphia Eagles,,Washington Redskins,boxscore,32,27,436,0,398,0
+1,Sun,2019-09-08,4:05PM,Seattle Seahawks,,Cincinnati Bengals,boxscore,21,20,232,1,429,3
+1,Sun,2019-09-08,4:05PM,Los Angeles Chargers,,Indianapolis Colts,boxscore,30,24,435,2,376,0
+1,Sun,2019-09-08,4:25PM,Detroit Lions,@,Arizona Cardinals,boxscore,27,27,477,2,387,1
+1,Sun,2019-09-08,4:25PM,Dallas Cowboys,,New York Giants,boxscore,35,17,494,0,470,2
+1,Sun,2019-09-08,4:25PM,San Francisco 49ers,@,Tampa Bay Buccaneers,boxscore,31,17,256,2,295,4
+1,Sun,2019-09-08,8:20PM,New England Patriots,,Pittsburgh Steelers,boxscore,33,3,465,0,308,1
+1,Mon,2019-09-09,7:10PM,New Orleans Saints,,Houston Texans,boxscore,30,28,510,1,414,1
+1,Mon,2019-09-09,10:20PM,Oakland Raiders,,Denver Broncos,boxscore,24,16,357,0,344,0
+2,Thu,2019-09-12,8:20PM,Tampa Bay Buccaneers,@,Carolina Panthers,boxscore,20,14,289,0,352,1
+2,Sun,2019-09-15,1:00PM,Buffalo Bills,@,New York Giants,boxscore,28,14,388,0,370,2
+2,Sun,2019-09-15,1:00PM,San Francisco 49ers,@,Cincinnati Bengals,boxscore,41,17,571,1,316,1
+2,Sun,2019-09-15,1:00PM,Indianapolis Colts,@,Tennessee Titans,boxscore,19,17,288,2,243,0
+2,Sun,2019-09-15,1:00PM,Baltimore Ravens,,Arizona Cardinals,boxscore,23,17,440,0,349,0
+2,Sun,2019-09-15,1:00PM,Dallas Cowboys,@,Washington Redskins,boxscore,31,21,474,1,255,0
+2,Sun,2019-09-15,1:00PM,Detroit Lions,,Los Angeles Chargers,boxscore,13,10,339,2,424,2
+2,Sun,2019-09-15,1:00PM,Green Bay Packers,,Minnesota Vikings,boxscore,21,16,335,2,421,4
+2,Sun,2019-09-15,1:00PM,Houston Texans,,Jacksonville Jaguars,boxscore,13,12,263,0,281,1
+2,Sun,2019-09-15,1:00PM,New England Patriots,@,Miami Dolphins,boxscore,43,0,379,1,184,4
+2,Sun,2019-09-15,1:00PM,Seattle Seahawks,@,Pittsburgh Steelers,boxscore,28,26,425,2,261,1
+2,Sun,2019-09-15,4:05PM,Kansas City Chiefs,@,Oakland Raiders,boxscore,28,10,467,1,307,2
+2,Sun,2019-09-15,4:25PM,Chicago Bears,@,Denver Broncos,boxscore,16,14,273,0,372,1
+2,Sun,2019-09-15,4:25PM,Los Angeles Rams,,New Orleans Saints,boxscore,27,9,380,1,244,1
+2,Sun,2019-09-15,8:20PM,Atlanta Falcons,,Philadelphia Eagles,boxscore,24,20,367,3,286,3
+2,Mon,2019-09-16,8:15PM,Cleveland Browns,@,New York Jets,boxscore,23,3,375,1,262,1
+3,Thu,2019-09-19,8:20PM,Jacksonville Jaguars,,Tennessee Titans,boxscore,20,7,292,0,340,1
+3,Sun,2019-09-22,1:00PM,Indianapolis Colts,,Atlanta Falcons,boxscore,27,24,379,0,397,1
+3,Sun,2019-09-22,1:00PM,Buffalo Bills,,Cincinnati Bengals,boxscore,21,17,416,2,306,4
+3,Sun,2019-09-22,1:00PM,Dallas Cowboys,,Miami Dolphins,boxscore,31,6,476,1,283,1
+3,Sun,2019-09-22,1:00PM,Green Bay Packers,,Denver Broncos,boxscore,27,16,312,0,310,3
+3,Sun,2019-09-22,1:00PM,Detroit Lions,@,Philadelphia Eagles,boxscore,27,24,287,0,373,2
+3,Sun,2019-09-22,1:00PM,Kansas City Chiefs,,Baltimore Ravens,boxscore,33,28,503,0,452,0
+3,Sun,2019-09-22,1:00PM,Minnesota Vikings,,Oakland Raiders,boxscore,34,14,385,0,302,1
+3,Sun,2019-09-22,1:00PM,New England Patriots,,New York Jets,boxscore,30,14,381,2,105,1
+3,Sun,2019-09-22,4:05PM,Carolina Panthers,@,Arizona Cardinals,boxscore,38,20,413,1,248,2
+3,Sun,2019-09-22,4:05PM,New York Giants,@,Tampa Bay Buccaneers,boxscore,32,31,384,2,499,1
+3,Sun,2019-09-22,4:25PM,Houston Texans,@,Los Angeles Chargers,boxscore,27,20,376,1,366,1
+3,Sun,2019-09-22,4:25PM,New Orleans Saints,@,Seattle Seahawks,boxscore,33,27,265,1,514,1
+3,Sun,2019-09-22,4:25PM,San Francisco 49ers,,Pittsburgh Steelers,boxscore,24,20,436,5,239,2
+3,Sun,2019-09-22,8:20PM,Los Angeles Rams,@,Cleveland Browns,boxscore,20,13,344,3,270,1
+3,Mon,2019-09-23,8:15PM,Chicago Bears,@,Washington Redskins,boxscore,31,15,298,1,356,5
+4,Thu,2019-09-26,8:20PM,Philadelphia Eagles,@,Green Bay Packers,boxscore,34,27,336,0,491,2
+4,Sun,2019-09-29,1:00PM,Tennessee Titans,@,Atlanta Falcons,boxscore,24,10,365,0,422,1
+4,Sun,2019-09-29,1:00PM,New England Patriots,@,Buffalo Bills,boxscore,16,10,224,1,375,4
+4,Sun,2019-09-29,1:00PM,Carolina Panthers,@,Houston Texans,boxscore,16,10,297,3,264,2
+4,Sun,2019-09-29,1:00PM,Cleveland Browns,@,Baltimore Ravens,boxscore,40,25,530,1,395,3
+4,Sun,2019-09-29,1:00PM,Oakland Raiders,@,Indianapolis Colts,boxscore,31,24,377,1,346,2
+4,Sun,2019-09-29,1:00PM,Kansas City Chiefs,@,Detroit Lions,boxscore,34,30,438,3,447,2
+4,Sun,2019-09-29,1:00PM,Los Angeles Chargers,@,Miami Dolphins,boxscore,30,10,390,0,233,1
+4,Sun,2019-09-29,1:00PM,New York Giants,,Washington Redskins,boxscore,24,3,389,4,176,4
+4,Sun,2019-09-29,4:05PM,Seattle Seahawks,@,Arizona Cardinals,boxscore,27,10,340,0,321,1
+4,Sun,2019-09-29,4:05PM,Tampa Bay Buccaneers,@,Los Angeles Rams,boxscore,55,40,464,1,518,4
+4,Sun,2019-09-29,4:25PM,Chicago Bears,,Minnesota Vikings,boxscore,16,6,269,0,222,2
+4,Sun,2019-09-29,4:25PM,Jacksonville Jaguars,@,Denver Broncos,boxscore,26,24,455,0,371,1
+4,Sun,2019-09-29,8:20PM,New Orleans Saints,,Dallas Cowboys,boxscore,12,10,266,1,257,3
+4,Mon,2019-09-30,8:15PM,Pittsburgh Steelers,,Cincinnati Bengals,boxscore,27,3,326,1,175,2
+5,Thu,2019-10-03,8:20PM,Seattle Seahawks,,Los Angeles Rams,boxscore,30,29,429,1,477,2
+5,Sun,2019-10-06,1:00PM,Philadelphia Eagles,,New York Jets,boxscore,31,6,265,1,128,3
+5,Sun,2019-10-06,1:00PM,Houston Texans,,Atlanta Falcons,boxscore,53,32,592,1,373,1
+5,Sun,2019-10-06,1:00PM,Buffalo Bills,@,Tennessee Titans,boxscore,14,7,313,1,252,0
+5,Sun,2019-10-06,1:00PM,Carolina Panthers,,Jacksonville Jaguars,boxscore,34,27,445,0,507,3
+5,Sun,2019-10-06,1:00PM,Oakland Raiders,,Chicago Bears,boxscore,24,21,398,2,236,2
+5,Sun,2019-10-06,1:00PM,Arizona Cardinals,@,Cincinnati Bengals,boxscore,26,23,514,0,370,0
+5,Sun,2019-10-06,1:00PM,Minnesota Vikings,@,New York Giants,boxscore,28,10,490,1,211,1
+5,Sun,2019-10-06,1:00PM,New Orleans Saints,,Tampa Bay Buccaneers,boxscore,31,24,457,1,252,0
+5,Sun,2019-10-06,1:00PM,New England Patriots,@,Washington Redskins,boxscore,33,7,442,1,223,2
+5,Sun,2019-10-06,1:00PM,Baltimore Ravens,@,Pittsburgh Steelers,boxscore,26,23,277,3,269,2
+5,Sun,2019-10-06,4:05PM,Denver Broncos,@,Los Angeles Chargers,boxscore,20,13,350,2,246,3
+5,Sun,2019-10-06,4:25PM,Green Bay Packers,@,Dallas Cowboys,boxscore,34,24,335,0,563,3
+5,Sun,2019-10-06,8:20PM,Indianapolis Colts,@,Kansas City Chiefs,boxscore,19,13,331,1,324,1
+5,Mon,2019-10-07,8:15PM,San Francisco 49ers,,Cleveland Browns,boxscore,31,3,446,0,180,4
+6,Thu,2019-10-10,8:20PM,New England Patriots,,New York Giants,boxscore,35,14,427,2,213,4
+6,Sun,2019-10-13,9:30AM,Carolina Panthers,@,Tampa Bay Buccaneers,boxscore,37,26,268,1,407,7
+6,Sun,2019-10-13,1:00PM,Washington Redskins,@,Miami Dolphins,boxscore,17,16,311,0,271,2
+6,Sun,2019-10-13,1:00PM,Baltimore Ravens,,Cincinnati Bengals,boxscore,23,17,497,1,250,1
+6,Sun,2019-10-13,1:00PM,Seattle Seahawks,@,Cleveland Browns,boxscore,32,28,454,1,406,4
+6,Sun,2019-10-13,1:00PM,Houston Texans,@,Kansas City Chiefs,boxscore,31,24,472,3,309,2
+6,Sun,2019-10-13,1:00PM,New Orleans Saints,@,Jacksonville Jaguars,boxscore,13,6,326,0,226,1
+6,Sun,2019-10-13,1:00PM,Minnesota Vikings,,Philadelphia Eagles,boxscore,38,20,447,2,400,3
+6,Sun,2019-10-13,4:05PM,Arizona Cardinals,,Atlanta Falcons,boxscore,34,33,442,0,444,0
+6,Sun,2019-10-13,4:05PM,San Francisco 49ers,@,Los Angeles Rams,boxscore,20,7,331,2,157,1
+6,Sun,2019-10-13,4:25PM,New York Jets,,Dallas Cowboys,boxscore,24,22,382,1,399,0
+6,Sun,2019-10-13,4:25PM,Denver Broncos,,Tennessee Titans,boxscore,16,0,270,1,204,3
+6,Sun,2019-10-13,8:20PM,Pittsburgh Steelers,@,Los Angeles Chargers,boxscore,24,17,256,1,348,3
+6,Mon,2019-10-14,8:15PM,Green Bay Packers,,Detroit Lions,boxscore,23,22,447,3,299,0
+7,Thu,2019-10-17,8:20PM,Kansas City Chiefs,@,Denver Broncos,boxscore,30,6,271,0,205,1
+7,Sun,2019-10-20,1:00PM,Buffalo Bills,,Miami Dolphins,boxscore,31,21,305,0,381,2
+7,Sun,2019-10-20,1:00PM,Indianapolis Colts,,Houston Texans,boxscore,30,23,383,1,391,2
+7,Sun,2019-10-20,1:00PM,Minnesota Vikings,@,Detroit Lions,boxscore,42,30,504,0,433,1
+7,Sun,2019-10-20,1:00PM,San Francisco 49ers,@,Washington Redskins,boxscore,9,0,283,1,154,1
+7,Sun,2019-10-20,1:00PM,Los Angeles Rams,@,Atlanta Falcons,boxscore,37,10,381,0,224,3
+7,Sun,2019-10-20,1:00PM,Jacksonville Jaguars,@,Cincinnati Bengals,boxscore,27,17,460,0,291,4
+7,Sun,2019-10-20,1:00PM,Arizona Cardinals,@,New York Giants,boxscore,27,21,245,0,263,3
+7,Sun,2019-10-20,1:00PM,Green Bay Packers,,Oakland Raiders,boxscore,42,24,481,0,484,2
+7,Sun,2019-10-20,4:05PM,Tennessee Titans,,Los Angeles Chargers,boxscore,23,20,403,1,365,1
+7,Sun,2019-10-20,4:25PM,New Orleans Saints,@,Chicago Bears,boxscore,36,25,424,0,252,2
+7,Sun,2019-10-20,4:25PM,Baltimore Ravens,@,Seattle Seahawks,boxscore,30,16,340,0,347,2
+7,Sun,2019-10-20,8:20PM,Dallas Cowboys,,Philadelphia Eagles,boxscore,37,10,402,1,283,4
+7,Mon,2019-10-21,8:15PM,New England Patriots,@,New York Jets,boxscore,33,0,323,1,154,6
+8,Thu,2019-10-24,8:20PM,Minnesota Vikings,,Washington Redskins,boxscore,19,9,434,1,216,2
+8,Sun,2019-10-27,1:00PM,Philadelphia Eagles,@,Buffalo Bills,boxscore,31,13,371,1,253,1
+8,Sun,2019-10-27,1:00PM,Los Angeles Chargers,@,Chicago Bears,boxscore,17,16,231,1,388,2
+8,Sun,2019-10-27,1:00PM,Indianapolis Colts,,Denver Broncos,boxscore,15,13,318,1,279,0
+8,Sun,2019-10-27,1:00PM,Detroit Lions,,New York Giants,boxscore,31,26,375,2,370,1
+8,Sun,2019-10-27,1:00PM,Seattle Seahawks,@,Atlanta Falcons,boxscore,27,20,322,0,510,3
+8,Sun,2019-10-27,1:00PM,Los Angeles Rams,,Cincinnati Bengals,boxscore,24,10,470,0,401,0
+8,Sun,2019-10-27,1:00PM,New Orleans Saints,,Arizona Cardinals,boxscore,31,9,510,1,237,0
+8,Sun,2019-10-27,1:00PM,Jacksonville Jaguars,,New York Jets,boxscore,29,15,389,1,213,3
+8,Sun,2019-10-27,1:00PM,Tennessee Titans,,Tampa Bay Buccaneers,boxscore,27,23,246,1,389,4
+8,Sun,2019-10-27,4:05PM,San Francisco 49ers,,Carolina Panthers,boxscore,51,13,388,1,230,3
+8,Sun,2019-10-27,4:25PM,New England Patriots,,Cleveland Browns,boxscore,27,13,318,0,310,3
+8,Sun,2019-10-27,4:25PM,Houston Texans,,Oakland Raiders,boxscore,27,24,388,0,378,0
+8,Sun,2019-10-27,8:20PM,Green Bay Packers,@,Kansas City Chiefs,boxscore,31,24,374,0,337,1
+8,Mon,2019-10-28,8:15PM,Pittsburgh Steelers,,Miami Dolphins,boxscore,27,14,394,1,230,4
+9,Thu,2019-10-31,8:20PM,San Francisco 49ers,@,Arizona Cardinals,boxscore,28,25,411,0,357,0
+9,Sun,2019-11-03,9:30AM,Houston Texans,@,Jacksonville Jaguars,boxscore,26,3,410,1,356,4
+9,Sun,2019-11-03,1:00PM,Buffalo Bills,,Washington Redskins,boxscore,24,9,268,0,243,0
+9,Sun,2019-11-03,1:00PM,Carolina Panthers,,Tennessee Titans,boxscore,30,20,370,1,431,3
+9,Sun,2019-11-03,1:00PM,Philadelphia Eagles,,Chicago Bears,boxscore,22,14,373,0,164,1
+9,Sun,2019-11-03,1:00PM,Pittsburgh Steelers,,Indianapolis Colts,boxscore,26,24,273,2,328,3
+9,Sun,2019-11-03,1:00PM,Miami Dolphins,,New York Jets,boxscore,26,18,316,0,321,1
+9,Sun,2019-11-03,1:00PM,Kansas City Chiefs,,Minnesota Vikings,boxscore,26,23,377,1,308,0
+9,Sun,2019-11-03,4:05PM,Oakland Raiders,,Detroit Lions,boxscore,31,24,450,0,473,2
+9,Sun,2019-11-03,4:05PM,Seattle Seahawks,,Tampa Bay Buccaneers,boxscore,40,34,492,1,418,1
+9,Sun,2019-11-03,4:25PM,Denver Broncos,,Cleveland Browns,boxscore,24,19,302,1,351,0
+9,Sun,2019-11-03,4:25PM,Los Angeles Chargers,,Green Bay Packers,boxscore,26,11,442,0,184,0
+9,Sun,2019-11-03,8:20PM,Baltimore Ravens,,New England Patriots,boxscore,37,20,372,2,342,2
+9,Mon,2019-11-04,8:15PM,Dallas Cowboys,@,New York Giants,boxscore,37,18,429,2,271,3
+10,Thu,2019-11-07,8:20PM,Oakland Raiders,,Los Angeles Chargers,boxscore,26,24,278,0,315,3
+10,Sun,2019-11-10,1:00PM,Atlanta Falcons,@,New Orleans Saints,boxscore,26,9,317,1,310,0
+10,Sun,2019-11-10,1:00PM,Cleveland Browns,,Buffalo Bills,boxscore,19,16,368,0,344,0
+10,Sun,2019-11-10,1:00PM,Chicago Bears,,Detroit Lions,boxscore,20,13,226,0,357,1
+10,Sun,2019-11-10,1:00PM,Baltimore Ravens,@,Cincinnati Bengals,boxscore,49,13,379,1,307,3
+10,Sun,2019-11-10,1:00PM,Tampa Bay Buccaneers,,Arizona Cardinals,boxscore,30,27,457,3,417,2
+10,Sun,2019-11-10,1:00PM,Tennessee Titans,,Kansas City Chiefs,boxscore,35,32,371,1,530,1
+10,Sun,2019-11-10,1:00PM,New York Jets,,New York Giants,boxscore,34,27,294,0,281,2
+10,Sun,2019-11-10,4:05PM,Miami Dolphins,@,Indianapolis Colts,boxscore,16,12,229,2,300,3
+10,Sun,2019-11-10,4:25PM,Green Bay Packers,,Carolina Panthers,boxscore,24,16,388,0,401,2
+10,Sun,2019-11-10,4:25PM,Pittsburgh Steelers,,Los Angeles Rams,boxscore,17,12,273,2,306,4
+10,Sun,2019-11-10,8:20PM,Minnesota Vikings,@,Dallas Cowboys,boxscore,28,24,364,0,443,1
+10,Mon,2019-11-11,8:15PM,Seattle Seahawks,@,San Francisco 49ers,boxscore,27,24,336,4,302,3
+11,Thu,2019-11-14,8:20PM,Cleveland Browns,,Pittsburgh Steelers,boxscore,21,7,293,0,236,4
+11,Sun,2019-11-17,1:00PM,Atlanta Falcons,@,Carolina Panthers,boxscore,29,3,349,0,347,4
+11,Sun,2019-11-17,1:00PM,Buffalo Bills,@,Miami Dolphins,boxscore,37,20,424,0,303,1
+11,Sun,2019-11-17,1:00PM,Indianapolis Colts,,Jacksonville Jaguars,boxscore,33,13,389,2,308,1
+11,Sun,2019-11-17,1:00PM,Dallas Cowboys,@,Detroit Lions,boxscore,35,27,509,1,312,0
+11,Sun,2019-11-17,1:00PM,Minnesota Vikings,,Denver Broncos,boxscore,27,23,321,2,394,1
+11,Sun,2019-11-17,1:00PM,Baltimore Ravens,,Houston Texans,boxscore,41,7,491,0,232,2
+11,Sun,2019-11-17,1:00PM,New Orleans Saints,@,Tampa Bay Buccaneers,boxscore,34,17,328,0,334,4
+11,Sun,2019-11-17,1:00PM,New York Jets,@,Washington Redskins,boxscore,34,17,400,2,225,1
+11,Sun,2019-11-17,4:05PM,San Francisco 49ers,,Arizona Cardinals,boxscore,36,26,442,2,266,2
+11,Sun,2019-11-17,4:25PM,Oakland Raiders,,Cincinnati Bengals,boxscore,17,10,386,2,246,2
+11,Sun,2019-11-17,4:25PM,New England Patriots,@,Philadelphia Eagles,boxscore,17,10,298,0,255,1
+11,Sun,2019-11-17,8:20PM,Los Angeles Rams,,Chicago Bears,boxscore,17,7,283,2,267,1
+11,Mon,2019-11-18,8:15PM,Kansas City Chiefs,@,Los Angeles Chargers,boxscore,24,17,310,1,438,4
+12,Thu,2019-11-21,8:20PM,Houston Texans,,Indianapolis Colts,boxscore,20,17,396,1,296,0
+12,Sun,2019-11-24,1:00PM,Tampa Bay Buccaneers,@,Atlanta Falcons,boxscore,35,22,446,2,337,2
+12,Sun,2019-11-24,1:00PM,Buffalo Bills,,Denver Broncos,boxscore,20,3,424,1,134,1
+12,Sun,2019-11-24,1:00PM,New Orleans Saints,,Carolina Panthers,boxscore,34,31,418,1,351,1
+12,Sun,2019-11-24,1:00PM,Chicago Bears,,New York Giants,boxscore,19,14,335,2,243,1
+12,Sun,2019-11-24,1:00PM,Pittsburgh Steelers,@,Cincinnati Bengals,boxscore,16,10,338,1,244,2
+12,Sun,2019-11-24,1:00PM,Cleveland Browns,,Miami Dolphins,boxscore,41,24,467,1,284,2
+12,Sun,2019-11-24,1:00PM,Washington Redskins,,Detroit Lions,boxscore,19,16,230,2,364,4
+12,Sun,2019-11-24,1:00PM,New York Jets,,Oakland Raiders,boxscore,34,3,401,1,208,2
+12,Sun,2019-11-24,1:00PM,Seattle Seahawks,@,Philadelphia Eagles,boxscore,17,9,348,2,344,5
+12,Sun,2019-11-24,4:05PM,Tennessee Titans,,Jacksonville Jaguars,boxscore,42,20,471,2,369,1
+12,Sun,2019-11-24,4:25PM,New England Patriots,,Dallas Cowboys,boxscore,13,9,282,0,321,1
+12,Sun,2019-11-24,8:20PM,San Francisco 49ers,,Green Bay Packers,boxscore,37,8,339,0,198,1
+12,Mon,2019-11-25,8:15PM,Baltimore Ravens,@,Los Angeles Rams,boxscore,45,6,480,0,221,2
+13,Thu,2019-11-28,12:30PM,Chicago Bears,@,Detroit Lions,boxscore,24,20,419,1,364,1
+13,Thu,2019-11-28,4:30PM,Buffalo Bills,@,Dallas Cowboys,boxscore,26,15,356,0,426,2
+13,Thu,2019-11-28,8:20PM,New Orleans Saints,@,Atlanta Falcons,boxscore,26,18,279,0,348,3
+13,Sun,2019-12-01,1:00PM,Washington Redskins,@,Carolina Panthers,boxscore,29,21,362,0,278,2
+13,Sun,2019-12-01,1:00PM,Cincinnati Bengals,,New York Jets,boxscore,22,6,277,0,271,0
+13,Sun,2019-12-01,1:00PM,Pittsburgh Steelers,,Cleveland Browns,boxscore,20,13,323,1,279,2
+13,Sun,2019-12-01,1:00PM,Tennessee Titans,@,Indianapolis Colts,boxscore,31,17,292,2,391,3
+13,Sun,2019-12-01,1:00PM,Green Bay Packers,@,New York Giants,boxscore,31,13,322,0,335,3
+13,Sun,2019-12-01,1:00PM,Tampa Bay Buccaneers,@,Jacksonville Jaguars,boxscore,28,11,315,1,242,4
+13,Sun,2019-12-01,1:00PM,Miami Dolphins,,Philadelphia Eagles,boxscore,37,31,409,1,386,1
+13,Sun,2019-12-01,1:00PM,Baltimore Ravens,,San Francisco 49ers,boxscore,20,17,283,1,331,1
+13,Sun,2019-12-01,4:05PM,Los Angeles Rams,@,Arizona Cardinals,boxscore,34,7,549,0,198,1
+13,Sun,2019-12-01,4:25PM,Denver Broncos,,Los Angeles Chargers,boxscore,23,20,218,1,359,2
+13,Sun,2019-12-01,4:25PM,Kansas City Chiefs,,Oakland Raiders,boxscore,40,9,259,0,332,3
+13,Sun,2019-12-01,8:20PM,Houston Texans,,New England Patriots,boxscore,28,22,276,0,448,1
+13,Mon,2019-12-02,8:15PM,Seattle Seahawks,,Minnesota Vikings,boxscore,37,30,444,2,354,3
+14,Thu,2019-12-05,8:20PM,Chicago Bears,,Dallas Cowboys,boxscore,31,24,382,2,408,0
+14,Sun,2019-12-08,1:00PM,Atlanta Falcons,,Carolina Panthers,boxscore,40,20,461,0,345,4
+14,Sun,2019-12-08,1:00PM,Baltimore Ravens,@,Buffalo Bills,boxscore,24,17,257,1,209,1
+14,Sun,2019-12-08,1:00PM,Cleveland Browns,,Cincinnati Bengals,boxscore,27,19,333,2,451,1
+14,Sun,2019-12-08,1:00PM,Tampa Bay Buccaneers,,Indianapolis Colts,boxscore,38,35,542,4,309,1
+14,Sun,2019-12-08,1:00PM,Denver Broncos,@,Houston Texans,boxscore,38,24,391,1,414,3
+14,Sun,2019-12-08,1:00PM,Minnesota Vikings,,Detroit Lions,boxscore,20,7,354,0,231,2
+14,Sun,2019-12-08,1:00PM,Green Bay Packers,,Washington Redskins,boxscore,20,15,341,1,262,1
+14,Sun,2019-12-08,1:00PM,New York Jets,,Miami Dolphins,boxscore,22,21,374,1,362,1
+14,Sun,2019-12-08,1:00PM,San Francisco 49ers,@,New Orleans Saints,boxscore,48,46,516,1,465,1
+14,Sun,2019-12-08,4:05PM,Los Angeles Chargers,@,Jacksonville Jaguars,boxscore,45,10,525,0,252,0
+14,Sun,2019-12-08,4:25PM,Pittsburgh Steelers,@,Arizona Cardinals,boxscore,23,17,275,2,236,3
+14,Sun,2019-12-08,4:25PM,Kansas City Chiefs,@,New England Patriots,boxscore,23,16,346,2,278,1
+14,Sun,2019-12-08,4:25PM,Tennessee Titans,@,Oakland Raiders,boxscore,42,21,552,1,355,1
+14,Sun,2019-12-08,8:20PM,Los Angeles Rams,,Seattle Seahawks,boxscore,28,12,455,2,308,1
+14,Mon,2019-12-09,8:15PM,Philadelphia Eagles,,New York Giants,boxscore,23,17,418,1,255,0
+15,Thu,2019-12-12,8:20PM,Baltimore Ravens,,New York Jets,boxscore,42,21,430,0,310,2
+15,Sun,2019-12-15,1:00PM,Seattle Seahawks,@,Carolina Panthers,boxscore,30,24,428,1,414,3
+15,Sun,2019-12-15,1:00PM,Green Bay Packers,,Chicago Bears,boxscore,21,13,292,0,415,3
+15,Sun,2019-12-15,1:00PM,New England Patriots,@,Cincinnati Bengals,boxscore,34,13,291,0,315,5
+15,Sun,2019-12-15,1:00PM,Kansas City Chiefs,,Denver Broncos,boxscore,23,3,419,1,251,1
+15,Sun,2019-12-15,1:00PM,Tampa Bay Buccaneers,@,Detroit Lions,boxscore,38,17,495,1,295,3
+15,Sun,2019-12-15,1:00PM,Houston Texans,@,Tennessee Titans,boxscore,24,21,374,2,432,1
+15,Sun,2019-12-15,1:00PM,New York Giants,,Miami Dolphins,boxscore,36,20,412,3,384,1
+15,Sun,2019-12-15,1:00PM,Philadelphia Eagles,@,Washington Redskins,boxscore,37,27,415,1,352,1
+15,Sun,2019-12-15,4:05PM,Arizona Cardinals,,Cleveland Browns,boxscore,38,24,445,1,393,2
+15,Sun,2019-12-15,4:05PM,Jacksonville Jaguars,@,Oakland Raiders,boxscore,20,16,262,0,364,0
+15,Sun,2019-12-15,4:05PM,Minnesota Vikings,@,Los Angeles Chargers,boxscore,39,10,344,1,345,7
+15,Sun,2019-12-15,4:25PM,Atlanta Falcons,@,San Francisco 49ers,boxscore,29,22,290,1,313,2
+15,Sun,2019-12-15,4:25PM,Dallas Cowboys,,Los Angeles Rams,boxscore,44,21,475,0,289,1
+15,Sun,2019-12-15,8:20PM,Buffalo Bills,@,Pittsburgh Steelers,boxscore,17,10,261,2,229,5
+15,Mon,2019-12-16,8:15PM,New Orleans Saints,,Indianapolis Colts,boxscore,34,7,424,0,205,0
+16,Sat,2019-12-21,1:00PM,Houston Texans,@,Tampa Bay Buccaneers,boxscore,23,20,229,2,435,5
+16,Sat,2019-12-21,4:30PM,New England Patriots,,Buffalo Bills,boxscore,24,17,414,1,268,0
+16,Sat,2019-12-21,8:15PM,San Francisco 49ers,,Los Angeles Rams,boxscore,34,31,334,2,395,1
+16,Sun,2019-12-22,1:00PM,Atlanta Falcons,,Jacksonville Jaguars,boxscore,24,12,518,2,288,1
+16,Sun,2019-12-22,1:00PM,Indianapolis Colts,,Carolina Panthers,boxscore,38,6,324,0,286,3
+16,Sun,2019-12-22,1:00PM,Miami Dolphins,,Cincinnati Bengals,boxscore,38,35,502,1,430,1
+16,Sun,2019-12-22,1:00PM,Baltimore Ravens,@,Cleveland Browns,boxscore,31,15,481,1,241,1
+16,Sun,2019-12-22,1:00PM,New Orleans Saints,@,Tennessee Titans,boxscore,38,28,377,0,397,1
+16,Sun,2019-12-22,1:00PM,New York Giants,@,Washington Redskins,boxscore,41,35,552,0,361,0
+16,Sun,2019-12-22,1:00PM,New York Jets,,Pittsburgh Steelers,boxscore,16,10,259,1,260,2
+16,Sun,2019-12-22,4:05PM,Denver Broncos,,Detroit Lions,boxscore,27,17,348,0,191,0
+16,Sun,2019-12-22,4:05PM,Oakland Raiders,@,Los Angeles Chargers,boxscore,24,17,366,0,284,0
+16,Sun,2019-12-22,4:25PM,Arizona Cardinals,@,Seattle Seahawks,boxscore,27,13,412,0,224,1
+16,Sun,2019-12-22,4:25PM,Philadelphia Eagles,,Dallas Cowboys,boxscore,17,9,431,0,311,1
+16,Sun,2019-12-22,8:20PM,Kansas City Chiefs,@,Chicago Bears,boxscore,26,3,350,0,234,0
+16,Mon,2019-12-23,8:15PM,Green Bay Packers,@,Minnesota Vikings,boxscore,23,10,383,3,139,1
+17,Sun,2019-12-29,1:00PM,Atlanta Falcons,@,Tampa Bay Buccaneers,boxscore,28,22,373,1,329,3
+17,Sun,2019-12-29,1:00PM,New York Jets,@,Buffalo Bills,boxscore,13,6,271,1,309,3
+17,Sun,2019-12-29,1:00PM,New Orleans Saints,@,Carolina Panthers,boxscore,42,10,379,0,329,3
+17,Sun,2019-12-29,1:00PM,Chicago Bears,@,Minnesota Vikings,boxscore,21,19,337,1,300,3
+17,Sun,2019-12-29,1:00PM,Cincinnati Bengals,,Cleveland Browns,boxscore,33,23,361,1,313,3
+17,Sun,2019-12-29,1:00PM,Green Bay Packers,@,Detroit Lions,boxscore,23,20,432,1,305,1
+17,Sun,2019-12-29,1:00PM,Kansas City Chiefs,,Los Angeles Chargers,boxscore,31,21,336,1,366,2
+17,Sun,2019-12-29,1:00PM,Miami Dolphins,@,New England Patriots,boxscore,27,24,389,0,352,2
+17,Sun,2019-12-29,4:25PM,Jacksonville Jaguars,,Indianapolis Colts,boxscore,38,20,353,1,275,2
+17,Sun,2019-12-29,4:25PM,Los Angeles Rams,,Arizona Cardinals,boxscore,31,24,424,0,393,5
+17,Sun,2019-12-29,4:25PM,Dallas Cowboys,,Washington Redskins,boxscore,47,16,517,1,271,2
+17,Sun,2019-12-29,4:25PM,Denver Broncos,,Oakland Raiders,boxscore,16,15,238,1,477,1
+17,Sun,2019-12-29,4:25PM,Tennessee Titans,@,Houston Texans,boxscore,35,14,467,0,301,1
+17,Sun,2019-12-29,4:25PM,Philadelphia Eagles,@,New York Giants,boxscore,34,17,400,0,397,2
+17,Sun,2019-12-29,4:25PM,Baltimore Ravens,,Pittsburgh Steelers,boxscore,28,10,304,2,168,2
+17,Sun,2019-12-29,8:20PM,San Francisco 49ers,@,Seattle Seahawks,boxscore,26,21,398,0,348,0

--- a/datasets/win-loss-score-2020-season.csv
+++ b/datasets/win-loss-score-2020-season.csv
@@ -1,0 +1,257 @@
+Week,Day,Date,Time,Winner/tie,,Loser/tie,,PtsW,PtsL,YdsW,TOW,YdsL,TOL
+1,Thu,2020-09-10,8:20PM,Kansas City Chiefs,,Houston Texans,boxscore,34,20,369,0,360,1
+1,Sun,2020-09-13,1:00PM,Seattle Seahawks,@,Atlanta Falcons,boxscore,38,25,383,0,506,2
+1,Sun,2020-09-13,1:00PM,Buffalo Bills,,New York Jets,boxscore,27,17,404,2,254,2
+1,Sun,2020-09-13,1:00PM,Las Vegas Raiders,@,Carolina Panthers,boxscore,34,30,372,0,388,0
+1,Sun,2020-09-13,1:00PM,Chicago Bears,@,Detroit Lions,boxscore,27,23,363,0,426,1
+1,Sun,2020-09-13,1:00PM,Baltimore Ravens,,Cleveland Browns,boxscore,38,6,381,1,306,3
+1,Sun,2020-09-13,1:00PM,Jacksonville Jaguars,,Indianapolis Colts,boxscore,27,20,241,0,445,2
+1,Sun,2020-09-13,1:00PM,Green Bay Packers,@,Minnesota Vikings,boxscore,43,34,522,0,382,1
+1,Sun,2020-09-13,1:00PM,New England Patriots,,Miami Dolphins,boxscore,21,11,357,1,269,3
+1,Sun,2020-09-13,1:00PM,Washington Football Team,,Philadelphia Eagles,boxscore,27,17,239,0,265,3
+1,Sun,2020-09-13,4:05PM,Los Angeles Chargers,@,Cincinnati Bengals,boxscore,16,13,362,0,295,2
+1,Sun,2020-09-13,4:25PM,Arizona Cardinals,@,San Francisco 49ers,boxscore,24,20,404,1,366,0
+1,Sun,2020-09-13,4:25PM,New Orleans Saints,,Tampa Bay Buccaneers,boxscore,34,23,271,0,310,3
+1,Sun,2020-09-13,8:20PM,Los Angeles Rams,,Dallas Cowboys,boxscore,20,17,422,1,380,0
+1,Mon,2020-09-14,7:15PM,Pittsburgh Steelers,@,New York Giants,boxscore,26,16,349,1,291,2
+1,Mon,2020-09-14,10:10PM,Tennessee Titans,@,Denver Broncos,boxscore,16,14,377,0,323,1
+2,Thu,2020-09-17,8:20PM,Cleveland Browns,,Cincinnati Bengals,boxscore,35,30,434,1,353,1
+2,Sun,2020-09-20,1:00PM,Dallas Cowboys,,Atlanta Falcons,boxscore,40,39,570,3,380,0
+2,Sun,2020-09-20,1:00PM,Buffalo Bills,@,Miami Dolphins,boxscore,31,28,523,1,410,0
+2,Sun,2020-09-20,1:00PM,Tampa Bay Buccaneers,,Carolina Panthers,boxscore,31,17,339,2,427,4
+2,Sun,2020-09-20,1:00PM,Chicago Bears,,New York Giants,boxscore,17,13,304,2,295,2
+2,Sun,2020-09-20,1:00PM,Indianapolis Colts,,Minnesota Vikings,boxscore,28,11,354,1,175,3
+2,Sun,2020-09-20,1:00PM,Pittsburgh Steelers,,Denver Broncos,boxscore,26,21,410,2,319,2
+2,Sun,2020-09-20,1:00PM,Green Bay Packers,,Detroit Lions,boxscore,42,21,488,0,307,1
+2,Sun,2020-09-20,1:00PM,Tennessee Titans,,Jacksonville Jaguars,boxscore,33,30,354,0,480,2
+2,Sun,2020-09-20,1:00PM,San Francisco 49ers,@,New York Jets,boxscore,31,13,359,1,277,0
+2,Sun,2020-09-20,1:00PM,Los Angeles Rams,@,Philadelphia Eagles,boxscore,37,19,449,1,363,3
+2,Sun,2020-09-20,4:05PM,Arizona Cardinals,,Washington Football Team,boxscore,30,15,438,1,316,2
+2,Sun,2020-09-20,4:25PM,Baltimore Ravens,@,Houston Texans,boxscore,33,16,407,0,304,2
+2,Sun,2020-09-20,4:25PM,Kansas City Chiefs,@,Los Angeles Chargers,boxscore,23,20,414,0,479,1
+2,Sun,2020-09-20,8:20PM,Seattle Seahawks,,New England Patriots,boxscore,35,30,429,1,464,1
+2,Mon,2020-09-21,8:15PM,Las Vegas Raiders,,New Orleans Saints,boxscore,34,24,377,1,424,1
+3,Thu,2020-09-24,8:20PM,Miami Dolphins,@,Jacksonville Jaguars,boxscore,31,13,294,0,318,2
+3,Sun,2020-09-27,1:00PM,Chicago Bears,@,Atlanta Falcons,boxscore,30,26,437,2,371,1
+3,Sun,2020-09-27,1:00PM,Buffalo Bills,,Los Angeles Rams,boxscore,35,32,375,2,478,2
+3,Sun,2020-09-27,1:00PM,Philadelphia Eagles,,Cincinnati Bengals,boxscore,23,23,378,2,304,0
+3,Sun,2020-09-27,1:00PM,Cleveland Browns,,Washington Football Team,boxscore,34,20,300,0,309,5
+3,Sun,2020-09-27,1:00PM,Pittsburgh Steelers,,Houston Texans,boxscore,28,21,387,0,260,1
+3,Sun,2020-09-27,1:00PM,Tennessee Titans,@,Minnesota Vikings,boxscore,31,30,444,1,464,3
+3,Sun,2020-09-27,1:00PM,New England Patriots,,Las Vegas Raiders,boxscore,36,20,406,1,375,3
+3,Sun,2020-09-27,1:00PM,San Francisco 49ers,@,New York Giants,boxscore,36,9,420,0,231,3
+3,Sun,2020-09-27,4:05PM,Carolina Panthers,@,Los Angeles Chargers,boxscore,21,16,302,0,436,4
+3,Sun,2020-09-27,4:05PM,Indianapolis Colts,,New York Jets,boxscore,36,7,353,0,260,3
+3,Sun,2020-09-27,4:25PM,Detroit Lions,@,Arizona Cardinals,boxscore,26,23,322,0,377,3
+3,Sun,2020-09-27,4:25PM,Seattle Seahawks,,Dallas Cowboys,boxscore,38,31,412,1,522,3
+3,Sun,2020-09-27,4:25PM,Tampa Bay Buccaneers,@,Denver Broncos,boxscore,28,10,353,0,226,2
+3,Sun,2020-09-27,8:20PM,Green Bay Packers,@,New Orleans Saints,boxscore,37,30,369,0,397,1
+3,Mon,2020-09-28,8:15PM,Kansas City Chiefs,@,Baltimore Ravens,boxscore,34,20,517,1,228,1
+4,Thu,2020-10-01,8:20PM,Denver Broncos,@,New York Jets,boxscore,37,28,359,3,321,0
+4,Sun,2020-10-04,1:00PM,Carolina Panthers,,Arizona Cardinals,boxscore,31,21,444,1,262,1
+4,Sun,2020-10-04,1:00PM,Indianapolis Colts,@,Chicago Bears,boxscore,19,11,289,0,269,1
+4,Sun,2020-10-04,1:00PM,Cincinnati Bengals,,Jacksonville Jaguars,boxscore,33,25,505,1,429,1
+4,Sun,2020-10-04,1:00PM,Cleveland Browns,@,Dallas Cowboys,boxscore,49,38,508,0,566,3
+4,Sun,2020-10-04,1:00PM,New Orleans Saints,@,Detroit Lions,boxscore,35,29,392,1,281,1
+4,Sun,2020-10-04,1:00PM,Minnesota Vikings,@,Houston Texans,boxscore,31,23,410,0,386,1
+4,Sun,2020-10-04,1:00PM,Seattle Seahawks,@,Miami Dolphins,boxscore,31,23,441,1,415,2
+4,Sun,2020-10-04,1:00PM,Baltimore Ravens,@,Washington Football Team,boxscore,31,17,350,2,343,1
+4,Sun,2020-10-04,1:00PM,Tampa Bay Buccaneers,,Los Angeles Chargers,boxscore,38,31,484,1,324,2
+4,Sun,2020-10-04,4:05PM,Los Angeles Rams,,New York Giants,boxscore,17,9,240,1,295,1
+4,Sun,2020-10-04,4:25PM,Buffalo Bills,@,Las Vegas Raiders,boxscore,30,23,337,0,383,2
+4,Sun,2020-10-04,8:20PM,Philadelphia Eagles,@,San Francisco 49ers,boxscore,25,20,267,1,417,3
+4,Mon,2020-10-05,7:05PM,Kansas City Chiefs,,New England Patriots,boxscore,26,10,323,1,357,4
+4,Mon,2020-10-05,8:15PM,Green Bay Packers,,Atlanta Falcons,boxscore,30,16,403,0,327,0
+5,Thu,2020-10-08,8:20PM,Chicago Bears,,Tampa Bay Buccaneers,boxscore,20,19,243,1,339,1
+5,Sun,2020-10-11,1:00PM,Carolina Panthers,@,Atlanta Falcons,boxscore,23,16,437,0,373,1
+5,Sun,2020-10-11,1:00PM,Baltimore Ravens,,Cincinnati Bengals,boxscore,27,3,332,1,205,3
+5,Sun,2020-10-11,1:00PM,Arizona Cardinals,@,New York Jets,boxscore,30,10,496,1,285,0
+5,Sun,2020-10-11,1:00PM,Houston Texans,,Jacksonville Jaguars,boxscore,30,14,486,2,364,2
+5,Sun,2020-10-11,1:00PM,Las Vegas Raiders,@,Kansas City Chiefs,boxscore,40,32,490,1,413,1
+5,Sun,2020-10-11,1:00PM,Pittsburgh Steelers,,Philadelphia Eagles,boxscore,38,29,367,1,336,2
+5,Sun,2020-10-11,1:00PM,Los Angeles Rams,@,Washington Football Team,boxscore,30,10,429,1,108,0
+5,Sun,2020-10-11,4:05PM,Miami Dolphins,@,San Francisco 49ers,boxscore,43,17,436,0,259,3
+5,Sun,2020-10-11,4:25PM,Cleveland Browns,,Indianapolis Colts,boxscore,32,23,385,2,308,2
+5,Sun,2020-10-11,4:25PM,Dallas Cowboys,,New York Giants,boxscore,37,34,402,2,300,1
+5,Sun,2020-10-11,8:20PM,Seattle Seahawks,,Minnesota Vikings,boxscore,27,26,314,1,449,2
+5,Mon,2020-10-12,8:15PM,New Orleans Saints,,Los Angeles Chargers,boxscore,30,27,408,1,350,0
+5,Tue,2020-10-13,7:00PM,Tennessee Titans,,Buffalo Bills,boxscore,42,16,334,0,370,3
+6,Sun,2020-10-18,1:00PM,Denver Broncos,@,New England Patriots,boxscore,18,12,299,2,288,3
+6,Sun,2020-10-18,1:00PM,Detroit Lions,@,Jacksonville Jaguars,boxscore,34,16,403,1,275,2
+6,Sun,2020-10-18,1:00PM,Atlanta Falcons,@,Minnesota Vikings,boxscore,40,23,462,1,365,3
+6,Sun,2020-10-18,1:00PM,Chicago Bears,@,Carolina Panthers,boxscore,23,16,261,1,303,3
+6,Sun,2020-10-18,1:00PM,Indianapolis Colts,,Cincinnati Bengals,boxscore,31,27,430,2,398,1
+6,Sun,2020-10-18,1:00PM,Pittsburgh Steelers,,Cleveland Browns,boxscore,38,7,277,0,220,2
+6,Sun,2020-10-18,1:00PM,Tennessee Titans,,Houston Texans,boxscore,42,36,607,2,412,0
+6,Sun,2020-10-18,1:00PM,New York Giants,,Washington Football Team,boxscore,20,19,240,1,337,2
+6,Sun,2020-10-18,1:00PM,Baltimore Ravens,@,Philadelphia Eagles,boxscore,30,28,355,0,364,1
+6,Sun,2020-10-18,4:05PM,Miami Dolphins,,New York Jets,boxscore,24,0,302,2,263,1
+6,Sun,2020-10-18,4:25PM,Tampa Bay Buccaneers,,Green Bay Packers,boxscore,38,10,324,0,201,2
+6,Sun,2020-10-18,8:20PM,San Francisco 49ers,,Los Angeles Rams,boxscore,24,16,390,0,311,1
+6,Mon,2020-10-19,5:00PM,Kansas City Chiefs,@,Buffalo Bills,boxscore,26,17,466,1,206,1
+6,Mon,2020-10-19,8:15PM,Arizona Cardinals,@,Dallas Cowboys,boxscore,38,10,438,0,344,4
+7,Thu,2020-10-22,8:20PM,Philadelphia Eagles,,New York Giants,boxscore,22,21,442,1,325,3
+7,Sun,2020-10-25,1:00PM,Green Bay Packers,@,Houston Texans,boxscore,35,20,379,0,365,1
+7,Sun,2020-10-25,1:00PM,Pittsburgh Steelers,@,Tennessee Titans,boxscore,27,24,362,3,292,0
+7,Sun,2020-10-25,1:00PM,Detroit Lions,@,Atlanta Falcons,boxscore,23,22,386,0,388,1
+7,Sun,2020-10-25,1:00PM,Buffalo Bills,@,New York Jets,boxscore,18,10,422,1,191,2
+7,Sun,2020-10-25,1:00PM,New Orleans Saints,,Carolina Panthers,boxscore,27,24,415,1,283,0
+7,Sun,2020-10-25,1:00PM,Cleveland Browns,@,Cincinnati Bengals,boxscore,37,34,398,1,468,2
+7,Sun,2020-10-25,1:00PM,Washington Football Team,,Dallas Cowboys,boxscore,25,3,397,0,142,1
+7,Sun,2020-10-25,4:05PM,Tampa Bay Buccaneers,@,Las Vegas Raiders,boxscore,45,20,454,0,347,1
+7,Sun,2020-10-25,4:25PM,Kansas City Chiefs,@,Denver Broncos,boxscore,43,16,286,1,411,4
+7,Sun,2020-10-25,4:25PM,San Francisco 49ers,@,New England Patriots,boxscore,33,6,467,2,241,4
+7,Sun,2020-10-25,4:25PM,Los Angeles Chargers,,Jacksonville Jaguars,boxscore,39,29,484,0,294,1
+7,Sun,2020-10-25,8:20PM,Arizona Cardinals,,Seattle Seahawks,boxscore,37,34,519,2,572,3
+7,Mon,2020-10-26,8:15PM,Los Angeles Rams,,Chicago Bears,boxscore,24,10,371,1,279,2
+8,Thu,2020-10-29,8:20PM,Atlanta Falcons,@,Carolina Panthers,boxscore,25,17,401,1,304,1
+8,Sun,2020-11-01,1:00PM,Indianapolis Colts,@,Detroit Lions,boxscore,41,21,366,0,326,2
+8,Sun,2020-11-01,1:00PM,Minnesota Vikings,@,Green Bay Packers,boxscore,28,22,324,0,400,1
+8,Sun,2020-11-01,1:00PM,Miami Dolphins,,Los Angeles Rams,boxscore,28,17,145,2,471,4
+8,Sun,2020-11-01,1:00PM,Pittsburgh Steelers,@,Baltimore Ravens,boxscore,28,24,221,1,457,4
+8,Sun,2020-11-01,1:00PM,Buffalo Bills,,New England Patriots,boxscore,24,21,339,1,349,1
+8,Sun,2020-11-01,1:00PM,Cincinnati Bengals,,Tennessee Titans,boxscore,31,20,367,0,441,1
+8,Sun,2020-11-01,1:00PM,Las Vegas Raiders,@,Cleveland Browns,boxscore,16,6,309,0,223,1
+8,Sun,2020-11-01,1:00PM,Kansas City Chiefs,,New York Jets,boxscore,35,9,496,0,221,1
+8,Sun,2020-11-01,4:05PM,Denver Broncos,,Los Angeles Chargers,boxscore,31,30,351,1,485,2
+8,Sun,2020-11-01,4:25PM,Seattle Seahawks,,San Francisco 49ers,boxscore,37,27,350,0,351,2
+8,Sun,2020-11-01,4:25PM,New Orleans Saints,@,Chicago Bears,boxscore,26,23,394,0,329,1
+8,Sun,2020-11-01,8:20PM,Philadelphia Eagles,,Dallas Cowboys,boxscore,23,9,222,4,265,2
+8,Mon,2020-11-02,8:15PM,Tampa Bay Buccaneers,@,New York Giants,boxscore,25,23,344,1,357,2
+9,Thu,2020-11-05,8:20PM,Green Bay Packers,@,San Francisco 49ers,boxscore,34,17,405,0,337,2
+9,Sun,2020-11-08,1:00PM,Baltimore Ravens,@,Indianapolis Colts,boxscore,24,10,266,1,339,2
+9,Sun,2020-11-08,1:00PM,Minnesota Vikings,,Detroit Lions,boxscore,34,20,487,0,421,3
+9,Sun,2020-11-08,1:00PM,Houston Texans,@,Jacksonville Jaguars,boxscore,27,25,374,1,403,1
+9,Sun,2020-11-08,1:00PM,Atlanta Falcons,,Denver Broncos,boxscore,34,27,363,1,405,1
+9,Sun,2020-11-08,1:00PM,Buffalo Bills,,Seattle Seahawks,boxscore,44,34,420,0,419,4
+9,Sun,2020-11-08,1:00PM,Kansas City Chiefs,,Carolina Panthers,boxscore,33,31,397,1,435,0
+9,Sun,2020-11-08,1:00PM,Tennessee Titans,,Chicago Bears,boxscore,24,17,228,0,375,2
+9,Sun,2020-11-08,1:00PM,New York Giants,@,Washington Football Team,boxscore,23,20,350,0,402,5
+9,Sun,2020-11-08,4:05PM,Las Vegas Raiders,@,Los Angeles Chargers,boxscore,31,26,320,1,440,1
+9,Sun,2020-11-08,4:25PM,Miami Dolphins,@,Arizona Cardinals,boxscore,34,31,312,0,442,1
+9,Sun,2020-11-08,4:25PM,Pittsburgh Steelers,@,Dallas Cowboys,boxscore,24,19,355,0,364,2
+9,Sun,2020-11-08,8:20PM,New Orleans Saints,@,Tampa Bay Buccaneers,boxscore,38,3,420,2,194,3
+9,Mon,2020-11-09,8:15PM,New England Patriots,@,New York Jets,boxscore,30,27,433,0,322,1
+10,Thu,2020-11-12,8:20PM,Indianapolis Colts,@,Tennessee Titans,boxscore,34,17,430,0,294,0
+10,Sun,2020-11-15,1:00PM,Cleveland Browns,,Houston Texans,boxscore,10,7,356,0,243,0
+10,Sun,2020-11-15,1:00PM,Detroit Lions,,Washington Football Team,boxscore,30,27,372,0,464,1
+10,Sun,2020-11-15,1:00PM,Green Bay Packers,,Jacksonville Jaguars,boxscore,24,20,395,2,260,1
+10,Sun,2020-11-15,1:00PM,Tampa Bay Buccaneers,@,Carolina Panthers,boxscore,46,23,544,1,187,1
+10,Sun,2020-11-15,1:00PM,New York Giants,,Philadelphia Eagles,boxscore,27,17,382,0,346,0
+10,Sun,2020-11-15,4:05PM,Las Vegas Raiders,,Denver Broncos,boxscore,37,12,357,0,313,5
+10,Sun,2020-11-15,4:05PM,Miami Dolphins,,Los Angeles Chargers,boxscore,29,21,280,1,273,1
+10,Sun,2020-11-15,4:05PM,Arizona Cardinals,,Buffalo Bills,boxscore,32,30,453,2,369,2
+10,Sun,2020-11-15,4:25PM,Pittsburgh Steelers,,Cincinnati Bengals,boxscore,36,10,377,0,324,2
+10,Sun,2020-11-15,4:25PM,New Orleans Saints,,San Francisco 49ers,boxscore,27,13,237,2,281,4
+10,Sun,2020-11-15,4:25PM,Los Angeles Rams,,Seattle Seahawks,boxscore,23,16,389,1,333,3
+10,Sun,2020-11-15,8:20PM,New England Patriots,,Baltimore Ravens,boxscore,23,17,308,0,357,1
+10,Mon,2020-11-16,8:15PM,Minnesota Vikings,@,Chicago Bears,boxscore,19,13,385,2,149,2
+11,Thu,2020-11-19,8:20PM,Seattle Seahawks,,Arizona Cardinals,boxscore,28,21,347,0,314,0
+11,Sun,2020-11-22,1:00PM,New Orleans Saints,,Atlanta Falcons,boxscore,24,9,376,1,248,2
+11,Sun,2020-11-22,1:00PM,Washington Football Team,,Cincinnati Bengals,boxscore,20,9,325,1,272,2
+11,Sun,2020-11-22,1:00PM,Cleveland Browns,,Philadelphia Eagles,boxscore,22,17,324,1,315,3
+11,Sun,2020-11-22,1:00PM,Houston Texans,,New England Patriots,boxscore,27,20,399,0,435,0
+11,Sun,2020-11-22,1:00PM,Pittsburgh Steelers,@,Jacksonville Jaguars,boxscore,27,3,373,1,206,4
+11,Sun,2020-11-22,1:00PM,Tennessee Titans,@,Baltimore Ravens,boxscore,30,24,423,1,306,1
+11,Sun,2020-11-22,1:00PM,Carolina Panthers,,Detroit Lions,boxscore,20,0,374,2,185,1
+11,Sun,2020-11-22,4:05PM,Denver Broncos,,Miami Dolphins,boxscore,20,13,459,2,223,1
+11,Sun,2020-11-22,4:05PM,Los Angeles Chargers,,New York Jets,boxscore,34,28,376,1,292,1
+11,Sun,2020-11-22,4:25PM,Indianapolis Colts,,Green Bay Packers,boxscore,34,31,420,2,367,4
+11,Sun,2020-11-22,4:25PM,Dallas Cowboys,@,Minnesota Vikings,boxscore,31,28,376,1,430,2
+11,Sun,2020-11-22,8:20PM,Kansas City Chiefs,@,Las Vegas Raiders,boxscore,35,31,460,1,364,1
+11,Mon,2020-11-23,8:15PM,Los Angeles Rams,@,Tampa Bay Buccaneers,boxscore,27,24,413,2,251,2
+12,Thu,2020-11-26,12:30PM,Houston Texans,@,Detroit Lions,boxscore,41,25,384,1,388,3
+12,Thu,2020-11-26,4:30PM,Washington Football Team,@,Dallas Cowboys,boxscore,41,16,338,1,247,2
+12,Sun,2020-11-29,1:00PM,Atlanta Falcons,,Las Vegas Raiders,boxscore,43,6,304,1,243,5
+12,Sun,2020-11-29,1:00PM,Buffalo Bills,,Los Angeles Chargers,boxscore,27,17,332,3,367,1
+12,Sun,2020-11-29,1:00PM,New York Giants,@,Cincinnati Bengals,boxscore,19,17,386,1,155,3
+12,Sun,2020-11-29,1:00PM,Cleveland Browns,@,Jacksonville Jaguars,boxscore,27,25,459,1,375,0
+12,Sun,2020-11-29,1:00PM,Tennessee Titans,@,Indianapolis Colts,boxscore,45,26,449,0,336,1
+12,Sun,2020-11-29,1:00PM,New England Patriots,,Arizona Cardinals,boxscore,20,17,179,2,298,1
+12,Sun,2020-11-29,1:00PM,Miami Dolphins,@,New York Jets,boxscore,20,3,345,2,260,2
+12,Sun,2020-11-29,1:00PM,Minnesota Vikings,,Carolina Panthers,boxscore,28,27,387,3,374,1
+12,Sun,2020-11-29,4:05PM,New Orleans Saints,@,Denver Broncos,boxscore,31,3,292,1,112,3
+12,Sun,2020-11-29,4:05PM,San Francisco 49ers,@,Los Angeles Rams,boxscore,23,20,345,3,308,4
+12,Sun,2020-11-29,4:25PM,Kansas City Chiefs,@,Tampa Bay Buccaneers,boxscore,27,24,543,1,417,2
+12,Sun,2020-11-29,8:20PM,Green Bay Packers,,Chicago Bears,boxscore,41,25,393,0,350,3
+12,Mon,2020-11-30,8:15PM,Seattle Seahawks,@,Philadelphia Eagles,boxscore,23,17,301,0,250,1
+12,Wed,2020-12-02,3:40PM,Pittsburgh Steelers,,Baltimore Ravens,boxscore,19,14,334,2,219,2
+13,Sun,2020-12-06,1:00PM,New Orleans Saints,@,Atlanta Falcons,boxscore,21,16,424,1,332,1
+13,Sun,2020-12-06,1:00PM,Detroit Lions,@,Chicago Bears,boxscore,34,30,460,1,389,1
+13,Sun,2020-12-06,1:00PM,Miami Dolphins,,Cincinnati Bengals,boxscore,19,7,406,1,196,2
+13,Sun,2020-12-06,1:00PM,Cleveland Browns,@,Tennessee Titans,boxscore,41,35,458,1,431,3
+13,Sun,2020-12-06,1:00PM,Indianapolis Colts,@,Houston Texans,boxscore,26,20,371,0,398,2
+13,Sun,2020-12-06,1:00PM,Minnesota Vikings,,Jacksonville Jaguars,boxscore,27,24,420,2,390,4
+13,Sun,2020-12-06,1:00PM,Las Vegas Raiders,@,New York Jets,boxscore,31,28,440,2,376,3
+13,Sun,2020-12-06,4:05PM,Los Angeles Rams,@,Arizona Cardinals,boxscore,38,28,463,1,232,2
+13,Sun,2020-12-06,4:05PM,New York Giants,@,Seattle Seahawks,boxscore,17,12,290,1,327,2
+13,Sun,2020-12-06,4:25PM,Green Bay Packers,,Philadelphia Eagles,boxscore,30,16,437,0,278,1
+13,Sun,2020-12-06,4:25PM,New England Patriots,@,Los Angeles Chargers,boxscore,45,0,291,0,258,2
+13,Sun,2020-12-06,8:20PM,Kansas City Chiefs,,Denver Broncos,boxscore,22,16,447,0,330,2
+13,Mon,2020-12-07,5:00PM,Washington Football Team,@,Pittsburgh Steelers,boxscore,23,17,318,0,326,1
+13,Mon,2020-12-07,8:15PM,Buffalo Bills,@,San Francisco 49ers,boxscore,34,24,449,1,402,2
+13,Tue,2020-12-08,8:05PM,Baltimore Ravens,,Dallas Cowboys,boxscore,34,17,401,1,388,1
+14,Thu,2020-12-10,8:20PM,Los Angeles Rams,,New England Patriots,boxscore,24,3,318,1,220,1
+14,Sun,2020-12-13,1:00PM,Denver Broncos,@,Carolina Panthers,boxscore,32,27,365,1,370,0
+14,Sun,2020-12-13,1:00PM,Chicago Bears,,Houston Texans,boxscore,36,7,410,0,263,2
+14,Sun,2020-12-13,1:00PM,Dallas Cowboys,@,Cincinnati Bengals,boxscore,30,7,272,0,309,3
+14,Sun,2020-12-13,1:00PM,Arizona Cardinals,@,New York Giants,boxscore,26,7,390,0,159,3
+14,Sun,2020-12-13,1:00PM,Tennessee Titans,@,Jacksonville Jaguars,boxscore,31,10,454,1,354,1
+14,Sun,2020-12-13,1:00PM,Kansas City Chiefs,@,Miami Dolphins,boxscore,33,27,448,4,367,1
+14,Sun,2020-12-13,1:00PM,Tampa Bay Buccaneers,,Minnesota Vikings,boxscore,26,14,303,0,335,1
+14,Sun,2020-12-13,4:05PM,Indianapolis Colts,@,Las Vegas Raiders,boxscore,44,27,456,0,424,3
+14,Sun,2020-12-13,4:05PM,Seattle Seahawks,,New York Jets,boxscore,40,3,410,1,185,1
+14,Sun,2020-12-13,4:25PM,Los Angeles Chargers,,Atlanta Falcons,boxscore,20,17,345,1,319,3
+14,Sun,2020-12-13,4:25PM,Green Bay Packers,@,Detroit Lions,boxscore,31,24,410,0,293,0
+14,Sun,2020-12-13,4:25PM,Philadelphia Eagles,,New Orleans Saints,boxscore,24,21,413,1,358,2
+14,Sun,2020-12-13,4:25PM,Washington Football Team,@,San Francisco 49ers,boxscore,23,15,193,1,344,3
+14,Sun,2020-12-13,8:20PM,Buffalo Bills,,Pittsburgh Steelers,boxscore,26,15,334,2,224,2
+14,Mon,2020-12-14,8:15PM,Baltimore Ravens,@,Cleveland Browns,boxscore,47,42,385,0,493,1
+15,Thu,2020-12-17,8:20PM,Los Angeles Chargers,@,Las Vegas Raiders,boxscore,30,27,402,0,449,1
+15,Sat,2020-12-19,4:30PM,Buffalo Bills,@,Denver Broncos,boxscore,48,19,534,1,255,1
+15,Sat,2020-12-19,8:15PM,Green Bay Packers,,Carolina Panthers,boxscore,24,16,291,0,364,1
+15,Sun,2020-12-20,1:00PM,Tampa Bay Buccaneers,@,Atlanta Falcons,boxscore,31,27,416,0,369,0
+15,Sun,2020-12-20,1:00PM,Chicago Bears,@,Minnesota Vikings,boxscore,33,27,397,1,407,1
+15,Sun,2020-12-20,1:00PM,Indianapolis Colts,,Houston Texans,boxscore,27,20,350,0,425,2
+15,Sun,2020-12-20,1:00PM,Dallas Cowboys,,San Francisco 49ers,boxscore,41,33,291,0,458,4
+15,Sun,2020-12-20,1:00PM,Tennessee Titans,,Detroit Lions,boxscore,46,25,463,0,430,3
+15,Sun,2020-12-20,1:00PM,Baltimore Ravens,,Jacksonville Jaguars,boxscore,40,14,409,1,267,1
+15,Sun,2020-12-20,1:00PM,Miami Dolphins,,New England Patriots,boxscore,22,12,383,1,303,1
+15,Sun,2020-12-20,1:00PM,Seattle Seahawks,@,Washington Football Team,boxscore,20,15,302,1,353,2
+15,Sun,2020-12-20,4:05PM,Arizona Cardinals,,Philadelphia Eagles,boxscore,33,26,526,3,422,0
+15,Sun,2020-12-20,4:05PM,New York Jets,@,Los Angeles Rams,boxscore,23,20,289,0,303,1
+15,Sun,2020-12-20,4:25PM,Kansas City Chiefs,@,New Orleans Saints,boxscore,32,29,411,1,285,1
+15,Sun,2020-12-20,8:20PM,Cleveland Browns,@,New York Giants,boxscore,20,6,392,0,288,0
+15,Mon,2020-12-21,8:15PM,Cincinnati Bengals,,Pittsburgh Steelers,boxscore,27,17,230,0,244,3
+16,Fri,2020-12-25,4:30PM,New Orleans Saints,,Minnesota Vikings,boxscore,52,33,583,2,364,0
+16,Sat,2020-12-26,1:00PM,Tampa Bay Buccaneers,@,Detroit Lions,boxscore,47,7,588,0,186,2
+16,Sat,2020-12-26,4:30PM,San Francisco 49ers,@,Arizona Cardinals,boxscore,20,12,398,1,350,2
+16,Sat,2020-12-26,8:15PM,Miami Dolphins,@,Las Vegas Raiders,boxscore,26,25,383,0,418,1
+16,Sun,2020-12-27,1:00PM,Kansas City Chiefs,,Atlanta Falcons,boxscore,17,14,395,2,367,1
+16,Sun,2020-12-27,1:00PM,Chicago Bears,@,Jacksonville Jaguars,boxscore,41,17,391,1,279,2
+16,Sun,2020-12-27,1:00PM,Cincinnati Bengals,@,Houston Texans,boxscore,37,31,540,0,488,1
+16,Sun,2020-12-27,1:00PM,New York Jets,,Cleveland Browns,boxscore,23,16,333,0,299,2
+16,Sun,2020-12-27,1:00PM,Pittsburgh Steelers,,Indianapolis Colts,boxscore,28,24,354,0,365,2
+16,Sun,2020-12-27,1:00PM,Baltimore Ravens,,New York Giants,boxscore,27,13,432,1,269,0
+16,Sun,2020-12-27,4:05PM,Carolina Panthers,@,Washington Football Team,boxscore,20,13,280,2,386,4
+16,Sun,2020-12-27,4:05PM,Los Angeles Chargers,,Denver Broncos,boxscore,19,16,316,0,396,2
+16,Sun,2020-12-27,4:25PM,Dallas Cowboys,,Philadelphia Eagles,boxscore,37,17,513,1,477,3
+16,Sun,2020-12-27,4:25PM,Seattle Seahawks,,Los Angeles Rams,boxscore,20,9,292,0,334,1
+16,Sun,2020-12-27,8:20PM,Green Bay Packers,,Tennessee Titans,boxscore,40,14,448,1,260,2
+16,Mon,2020-12-28,8:15PM,Buffalo Bills,@,New England Patriots,boxscore,38,9,474,0,201,0
+17,Sun,2021-01-03,1:00PM,Tampa Bay Buccaneers,,Atlanta Falcons,boxscore,44,27,485,1,385,2
+17,Sun,2021-01-03,1:00PM,Buffalo Bills,,Miami Dolphins,boxscore,56,26,455,2,454,4
+17,Sun,2021-01-03,1:00PM,Baltimore Ravens,@,Cincinnati Bengals,boxscore,38,3,525,1,195,2
+17,Sun,2021-01-03,1:00PM,Cleveland Browns,,Pittsburgh Steelers,boxscore,24,22,358,0,394,1
+17,Sun,2021-01-03,1:00PM,New York Giants,,Dallas Cowboys,boxscore,23,19,336,2,307,1
+17,Sun,2021-01-03,1:00PM,Minnesota Vikings,@,Detroit Lions,boxscore,37,35,508,0,417,2
+17,Sun,2021-01-03,1:00PM,New England Patriots,,New York Jets,boxscore,28,14,404,0,350,2
+17,Sun,2021-01-03,4:25PM,New Orleans Saints,@,Carolina Panthers,boxscore,33,7,347,0,320,5
+17,Sun,2021-01-03,4:25PM,Green Bay Packers,@,Chicago Bears,boxscore,35,16,316,1,356,2
+17,Sun,2021-01-03,4:25PM,Indianapolis Colts,,Jacksonville Jaguars,boxscore,28,14,437,1,283,1
+17,Sun,2021-01-03,4:25PM,Los Angeles Rams,,Arizona Cardinals,boxscore,18,7,333,2,214,1
+17,Sun,2021-01-03,4:25PM,Las Vegas Raiders,@,Denver Broncos,boxscore,32,31,465,4,446,0
+17,Sun,2021-01-03,4:25PM,Tennessee Titans,@,Houston Texans,boxscore,41,38,492,1,457,1
+17,Sun,2021-01-03,4:25PM,Los Angeles Chargers,@,Kansas City Chiefs,boxscore,38,21,416,0,268,1
+17,Sun,2021-01-03,4:25PM,Seattle Seahawks,@,San Francisco 49ers,boxscore,26,23,280,0,328,1
+17,Sun,2021-01-03,8:20PM,Washington Football Team,@,Philadelphia Eagles,boxscore,20,14,248,2,216,3

--- a/datasets/win-loss-score-2021-season.csv
+++ b/datasets/win-loss-score-2021-season.csv
@@ -1,0 +1,273 @@
+Week,Day,Date,Time,Winner/tie,,Loser/tie,,PtsW,PtsL,YdsW,TOW,YdsL,TOL
+1,Thu,2021-09-09,8:20PM,Tampa Bay Buccaneers,,Dallas Cowboys,boxscore,31,29,431,4,451,1
+1,Sun,2021-09-12,1:00PM,Philadelphia Eagles,@,Atlanta Falcons,boxscore,32,6,434,0,260,0
+1,Sun,2021-09-12,1:00PM,Pittsburgh Steelers,@,Buffalo Bills,boxscore,23,16,252,0,371,1
+1,Sun,2021-09-12,1:00PM,Carolina Panthers,,New York Jets,boxscore,19,14,381,1,252,1
+1,Sun,2021-09-12,1:00PM,Cincinnati Bengals,,Minnesota Vikings,boxscore,27,24,366,0,403,1
+1,Sun,2021-09-12,1:00PM,Seattle Seahawks,@,Indianapolis Colts,boxscore,28,16,381,1,336,1
+1,Sun,2021-09-12,1:00PM,Arizona Cardinals,@,Tennessee Titans,boxscore,38,13,416,1,248,3
+1,Sun,2021-09-12,1:00PM,San Francisco 49ers,@,Detroit Lions,boxscore,41,33,442,2,430,1
+1,Sun,2021-09-12,1:00PM,Houston Texans,,Jacksonville Jaguars,boxscore,37,21,449,0,395,3
+1,Sun,2021-09-12,1:00PM,Los Angeles Chargers,@,Washington Football Team,boxscore,20,16,424,2,259,1
+1,Sun,2021-09-12,4:25PM,Kansas City Chiefs,,Cleveland Browns,boxscore,33,29,397,0,457,2
+1,Sun,2021-09-12,4:25PM,Denver Broncos,@,New York Giants,boxscore,27,13,420,1,314,1
+1,Sun,2021-09-12,4:25PM,New Orleans Saints,,Green Bay Packers,boxscore,38,3,322,0,229,3
+1,Sun,2021-09-12,4:25PM,Miami Dolphins,@,New England Patriots,boxscore,17,16,259,1,393,2
+1,Sun,2021-09-12,8:20PM,Los Angeles Rams,,Chicago Bears,boxscore,34,14,386,0,322,2
+1,Mon,2021-09-13,8:15PM,Las Vegas Raiders,,Baltimore Ravens,boxscore,33,27,491,1,406,2
+2,Thu,2021-09-16,8:20PM,Washington Football Team,,New York Giants,boxscore,30,29,407,1,391,0
+2,Sun,2021-09-19,1:00PM,Buffalo Bills,@,Miami Dolphins,boxscore,35,0,314,2,216,3
+2,Sun,2021-09-19,1:00PM,Carolina Panthers,,New Orleans Saints,boxscore,26,7,383,1,128,2
+2,Sun,2021-09-19,1:00PM,Chicago Bears,,Cincinnati Bengals,boxscore,20,17,206,1,248,4
+2,Sun,2021-09-19,1:00PM,Cleveland Browns,,Houston Texans,boxscore,31,21,355,2,302,2
+2,Sun,2021-09-19,1:00PM,Los Angeles Rams,@,Indianapolis Colts,boxscore,27,24,371,2,354,2
+2,Sun,2021-09-19,1:00PM,Denver Broncos,@,Jacksonville Jaguars,boxscore,23,13,398,0,189,2
+2,Sun,2021-09-19,1:00PM,New England Patriots,@,New York Jets,boxscore,25,6,260,0,336,4
+2,Sun,2021-09-19,1:00PM,San Francisco 49ers,@,Philadelphia Eagles,boxscore,17,11,306,0,328,0
+2,Sun,2021-09-19,1:00PM,Las Vegas Raiders,@,Pittsburgh Steelers,boxscore,26,17,425,0,331,1
+2,Sun,2021-09-19,4:05PM,Tampa Bay Buccaneers,,Atlanta Falcons,boxscore,48,25,341,1,348,3
+2,Sun,2021-09-19,4:05PM,Arizona Cardinals,,Minnesota Vikings,boxscore,34,33,474,2,419,0
+2,Sun,2021-09-19,4:25PM,Dallas Cowboys,@,Los Angeles Chargers,boxscore,20,17,419,1,408,2
+2,Sun,2021-09-19,4:25PM,Tennessee Titans,@,Seattle Seahawks,boxscore,33,30,532,1,397,0
+2,Sun,2021-09-19,8:20PM,Baltimore Ravens,,Kansas City Chiefs,boxscore,36,35,481,2,405,2
+2,Mon,2021-09-20,8:15PM,Green Bay Packers,,Detroit Lions,boxscore,35,17,323,0,344,2
+3,Thu,2021-09-23,8:20PM,Carolina Panthers,@,Houston Texans,boxscore,24,9,407,0,193,0
+3,Sun,2021-09-26,1:00PM,Atlanta Falcons,@,New York Giants,boxscore,17,14,296,1,346,1
+3,Sun,2021-09-26,1:00PM,Buffalo Bills,,Washington Football Team,boxscore,43,21,481,0,290,3
+3,Sun,2021-09-26,1:00PM,Cleveland Browns,,Chicago Bears,boxscore,26,6,418,0,47,0
+3,Sun,2021-09-26,1:00PM,Cincinnati Bengals,@,Pittsburgh Steelers,boxscore,24,10,268,1,342,2
+3,Sun,2021-09-26,1:00PM,Tennessee Titans,,Indianapolis Colts,boxscore,25,16,368,3,265,0
+3,Sun,2021-09-26,1:00PM,Arizona Cardinals,@,Jacksonville Jaguars,boxscore,31,19,407,1,361,4
+3,Sun,2021-09-26,1:00PM,Baltimore Ravens,@,Detroit Lions,boxscore,19,17,387,1,285,0
+3,Sun,2021-09-26,1:00PM,Los Angeles Chargers,@,Kansas City Chiefs,boxscore,30,24,352,0,437,4
+3,Sun,2021-09-26,1:00PM,New Orleans Saints,@,New England Patriots,boxscore,28,13,252,0,300,3
+3,Sun,2021-09-26,4:05PM,Denver Broncos,,New York Jets,boxscore,26,0,343,1,162,2
+3,Sun,2021-09-26,4:05PM,Las Vegas Raiders,,Miami Dolphins,boxscore,31,28,497,1,330,0
+3,Sun,2021-09-26,4:25PM,Minnesota Vikings,,Seattle Seahawks,boxscore,30,17,453,0,389,0
+3,Sun,2021-09-26,4:25PM,Los Angeles Rams,,Tampa Bay Buccaneers,boxscore,34,24,407,0,446,0
+3,Sun,2021-09-26,8:20PM,Green Bay Packers,@,San Francisco 49ers,boxscore,30,28,353,0,298,2
+3,Mon,2021-09-27,8:15PM,Dallas Cowboys,,Philadelphia Eagles,boxscore,41,21,380,1,367,2
+4,Thu,2021-09-30,8:20PM,Cincinnati Bengals,,Jacksonville Jaguars,boxscore,24,21,420,0,341,0
+4,Sun,2021-10-03,1:00PM,Washington Football Team,@,Atlanta Falcons,boxscore,34,30,412,0,374,0
+4,Sun,2021-10-03,1:00PM,Buffalo Bills,,Houston Texans,boxscore,40,0,450,1,109,5
+4,Sun,2021-10-03,1:00PM,Dallas Cowboys,,Carolina Panthers,boxscore,36,28,433,0,379,2
+4,Sun,2021-10-03,1:00PM,Chicago Bears,,Detroit Lions,boxscore,24,14,373,1,351,2
+4,Sun,2021-10-03,1:00PM,Cleveland Browns,@,Minnesota Vikings,boxscore,14,7,327,0,255,1
+4,Sun,2021-10-03,1:00PM,Indianapolis Colts,@,Miami Dolphins,boxscore,27,17,349,1,203,2
+4,Sun,2021-10-03,1:00PM,Kansas City Chiefs,@,Philadelphia Eagles,boxscore,42,30,471,1,461,0
+4,Sun,2021-10-03,1:00PM,New York Giants,@,New Orleans Saints,boxscore,27,21,485,1,405,1
+4,Sun,2021-10-03,1:00PM,New York Jets,,Tennessee Titans,boxscore,27,24,355,1,430,0
+4,Sun,2021-10-03,4:05PM,Arizona Cardinals,@,Los Angeles Rams,boxscore,37,20,465,0,401,2
+4,Sun,2021-10-03,4:05PM,Seattle Seahawks,@,San Francisco 49ers,boxscore,28,21,234,0,457,2
+4,Sun,2021-10-03,4:25PM,Baltimore Ravens,@,Denver Broncos,boxscore,23,7,406,0,254,1
+4,Sun,2021-10-03,4:25PM,Green Bay Packers,,Pittsburgh Steelers,boxscore,27,17,367,1,282,2
+4,Sun,2021-10-03,8:20PM,Tampa Bay Buccaneers,@,New England Patriots,boxscore,19,17,381,0,294,2
+4,Mon,2021-10-04,8:15PM,Los Angeles Chargers,,Las Vegas Raiders,boxscore,28,14,380,0,213,1
+5,Thu,2021-10-07,8:20PM,Los Angeles Rams,@,Seattle Seahawks,boxscore,26,17,476,1,354,2
+5,Sun,2021-10-10,9:30AM,Atlanta Falcons,,New York Jets,boxscore,27,20,450,2,230,1
+5,Sun,2021-10-10,1:00PM,Philadelphia Eagles,@,Carolina Panthers,boxscore,21,18,273,2,267,3
+5,Sun,2021-10-10,1:00PM,Green Bay Packers,@,Cincinnati Bengals,boxscore,25,22,466,1,367,2
+5,Sun,2021-10-10,1:00PM,Pittsburgh Steelers,,Denver Broncos,boxscore,27,19,391,1,374,1
+5,Sun,2021-10-10,1:00PM,Minnesota Vikings,,Detroit Lions,boxscore,19,17,384,2,288,2
+5,Sun,2021-10-10,1:00PM,New England Patriots,@,Houston Texans,boxscore,25,22,352,2,360,1
+5,Sun,2021-10-10,1:00PM,Tennessee Titans,@,Jacksonville Jaguars,boxscore,37,19,368,0,454,2
+5,Sun,2021-10-10,1:00PM,Tampa Bay Buccaneers,,Miami Dolphins,boxscore,45,17,558,0,301,2
+5,Sun,2021-10-10,1:00PM,New Orleans Saints,@,Washington Football Team,boxscore,33,22,369,2,373,2
+5,Sun,2021-10-10,4:05PM,Chicago Bears,@,Las Vegas Raiders,boxscore,20,9,252,0,259,1
+5,Sun,2021-10-10,4:05PM,Los Angeles Chargers,,Cleveland Browns,boxscore,47,42,493,1,531,0
+5,Sun,2021-10-10,4:25PM,Arizona Cardinals,,San Francisco 49ers,boxscore,17,10,304,1,338,1
+5,Sun,2021-10-10,4:25PM,Dallas Cowboys,,New York Giants,boxscore,44,20,515,2,367,2
+5,Sun,2021-10-10,8:20PM,Buffalo Bills,@,Kansas City Chiefs,boxscore,38,20,436,0,392,4
+5,Mon,2021-10-11,8:15PM,Baltimore Ravens,,Indianapolis Colts,boxscore,31,25,523,1,513,1
+6,Thu,2021-10-14,8:20PM,Tampa Bay Buccaneers,@,Philadelphia Eagles,boxscore,28,22,399,1,213,1
+6,Sun,2021-10-17,9:30AM,Jacksonville Jaguars,,Miami Dolphins,boxscore,23,20,396,1,431,1
+6,Sun,2021-10-17,1:00PM,Minnesota Vikings,@,Carolina Panthers,boxscore,34,28,571,1,306,3
+6,Sun,2021-10-17,1:00PM,Green Bay Packers,@,Chicago Bears,boxscore,24,14,323,0,277,1
+6,Sun,2021-10-17,1:00PM,Cincinnati Bengals,@,Detroit Lions,boxscore,34,11,398,1,228,1
+6,Sun,2021-10-17,1:00PM,Indianapolis Colts,,Houston Texans,boxscore,31,3,388,0,353,3
+6,Sun,2021-10-17,1:00PM,Kansas City Chiefs,@,Washington Football Team,boxscore,31,13,499,3,276,2
+6,Sun,2021-10-17,1:00PM,Los Angeles Rams,@,New York Giants,boxscore,38,11,365,2,261,4
+6,Sun,2021-10-17,1:00PM,Baltimore Ravens,,Los Angeles Chargers,boxscore,34,6,327,2,208,1
+6,Sun,2021-10-17,4:05PM,Arizona Cardinals,@,Cleveland Browns,boxscore,37,14,352,0,290,3
+6,Sun,2021-10-17,4:25PM,Dallas Cowboys,@,New England Patriots,boxscore,35,29,567,2,335,2
+6,Sun,2021-10-17,4:25PM,Las Vegas Raiders,@,Denver Broncos,boxscore,34,24,426,0,421,4
+6,Sun,2021-10-17,8:20PM,Pittsburgh Steelers,,Seattle Seahawks,boxscore,23,20,345,1,309,1
+6,Mon,2021-10-18,8:15PM,Tennessee Titans,,Buffalo Bills,boxscore,34,31,362,1,417,1
+7,Thu,2021-10-21,8:20PM,Cleveland Browns,,Denver Broncos,boxscore,17,14,376,0,223,1
+7,Sun,2021-10-24,1:00PM,Atlanta Falcons,@,Miami Dolphins,boxscore,30,28,397,2,413,2
+7,Sun,2021-10-24,1:00PM,New York Giants,,Carolina Panthers,boxscore,25,3,302,0,173,1
+7,Sun,2021-10-24,1:00PM,Cincinnati Bengals,@,Baltimore Ravens,boxscore,41,17,520,1,393,0
+7,Sun,2021-10-24,1:00PM,Green Bay Packers,,Washington Football Team,boxscore,24,10,304,1,430,2
+7,Sun,2021-10-24,1:00PM,Tennessee Titans,,Kansas City Chiefs,boxscore,27,3,369,1,334,3
+7,Sun,2021-10-24,1:00PM,New England Patriots,,New York Jets,boxscore,54,13,551,0,299,3
+7,Sun,2021-10-24,4:05PM,Los Angeles Rams,,Detroit Lions,boxscore,28,19,374,0,415,2
+7,Sun,2021-10-24,4:05PM,Las Vegas Raiders,,Philadelphia Eagles,boxscore,33,22,442,1,358,2
+7,Sun,2021-10-24,4:25PM,Tampa Bay Buccaneers,,Chicago Bears,boxscore,38,3,408,1,311,5
+7,Sun,2021-10-24,4:25PM,Arizona Cardinals,,Houston Texans,boxscore,31,5,397,1,160,1
+7,Sun,2021-10-24,8:20PM,Indianapolis Colts,@,San Francisco 49ers,boxscore,30,18,295,2,280,4
+7,Mon,2021-10-25,8:15PM,New Orleans Saints,@,Seattle Seahawks,boxscore,13,10,304,1,219,0
+8,Thu,2021-10-28,8:20PM,Green Bay Packers,@,Arizona Cardinals,boxscore,24,21,335,0,334,3
+8,Sun,2021-10-31,1:00PM,Carolina Panthers,@,Atlanta Falcons,boxscore,19,13,332,1,213,2
+8,Sun,2021-10-31,1:00PM,Buffalo Bills,,Miami Dolphins,boxscore,26,11,351,0,262,2
+8,Sun,2021-10-31,1:00PM,San Francisco 49ers,@,Chicago Bears,boxscore,33,22,467,0,324,1
+8,Sun,2021-10-31,1:00PM,New York Jets,,Cincinnati Bengals,boxscore,34,31,511,3,318,1
+8,Sun,2021-10-31,1:00PM,Pittsburgh Steelers,@,Cleveland Browns,boxscore,15,10,370,0,306,1
+8,Sun,2021-10-31,1:00PM,Tennessee Titans,@,Indianapolis Colts,boxscore,34,31,340,2,307,3
+8,Sun,2021-10-31,1:00PM,Philadelphia Eagles,@,Detroit Lions,boxscore,44,6,350,0,228,1
+8,Sun,2021-10-31,1:00PM,Los Angeles Rams,@,Houston Texans,boxscore,38,22,467,0,323,1
+8,Sun,2021-10-31,4:05PM,Seattle Seahawks,,Jacksonville Jaguars,boxscore,31,7,229,0,309,1
+8,Sun,2021-10-31,4:05PM,New England Patriots,@,Los Angeles Chargers,boxscore,27,24,352,1,369,2
+8,Sun,2021-10-31,4:25PM,New Orleans Saints,,Tampa Bay Buccaneers,boxscore,36,27,361,0,421,3
+8,Sun,2021-10-31,4:25PM,Denver Broncos,,Washington Football Team,boxscore,17,10,273,1,342,2
+8,Sun,2021-10-31,8:20PM,Dallas Cowboys,@,Minnesota Vikings,boxscore,20,16,419,2,278,0
+8,Mon,2021-11-01,8:15PM,Kansas City Chiefs,,New York Giants,boxscore,20,17,368,2,300,1
+9,Thu,2021-11-04,8:20PM,Indianapolis Colts,,New York Jets,boxscore,45,30,532,0,486,2
+9,Sun,2021-11-07,1:00PM,Atlanta Falcons,@,New Orleans Saints,boxscore,27,25,366,0,376,1
+9,Sun,2021-11-07,1:00PM,Jacksonville Jaguars,,Buffalo Bills,boxscore,9,6,218,1,301,3
+9,Sun,2021-11-07,1:00PM,Denver Broncos,@,Dallas Cowboys,boxscore,30,16,407,0,290,2
+9,Sun,2021-11-07,1:00PM,Baltimore Ravens,,Minnesota Vikings,boxscore,34,31,500,2,318,0
+9,Sun,2021-11-07,1:00PM,New England Patriots,@,Carolina Panthers,boxscore,24,6,273,2,240,3
+9,Sun,2021-11-07,1:00PM,Cleveland Browns,@,Cincinnati Bengals,boxscore,41,16,361,0,348,3
+9,Sun,2021-11-07,1:00PM,Miami Dolphins,,Houston Texans,boxscore,17,9,262,5,272,4
+9,Sun,2021-11-07,1:00PM,New York Giants,,Las Vegas Raiders,boxscore,23,16,247,1,403,3
+9,Sun,2021-11-07,4:05PM,Los Angeles Chargers,@,Philadelphia Eagles,boxscore,27,24,445,0,331,0
+9,Sun,2021-11-07,4:25PM,Arizona Cardinals,@,San Francisco 49ers,boxscore,31,17,437,0,337,3
+9,Sun,2021-11-07,4:25PM,Kansas City Chiefs,,Green Bay Packers,boxscore,13,7,237,0,301,2
+9,Sun,2021-11-07,8:20PM,Tennessee Titans,@,Los Angeles Rams,boxscore,28,16,194,1,347,2
+9,Mon,2021-11-08,8:15PM,Pittsburgh Steelers,,Chicago Bears,boxscore,29,27,280,1,414,2
+10,Thu,2021-11-11,8:20PM,Miami Dolphins,,Baltimore Ravens,boxscore,22,10,350,0,304,2
+10,Sun,2021-11-14,1:00PM,Dallas Cowboys,,Atlanta Falcons,boxscore,43,3,431,1,214,3
+10,Sun,2021-11-14,1:00PM,Buffalo Bills,@,New York Jets,boxscore,45,17,489,2,366,5
+10,Sun,2021-11-14,1:00PM,Pittsburgh Steelers,,Detroit Lions,boxscore,16,16,387,3,306,0
+10,Sun,2021-11-14,1:00PM,Tennessee Titans,,New Orleans Saints,boxscore,23,21,264,0,373,1
+10,Sun,2021-11-14,1:00PM,Washington Football Team,,Tampa Bay Buccaneers,boxscore,29,19,320,1,273,2
+10,Sun,2021-11-14,1:00PM,New England Patriots,,Cleveland Browns,boxscore,45,7,452,0,217,1
+10,Sun,2021-11-14,1:00PM,Indianapolis Colts,,Jacksonville Jaguars,boxscore,23,17,295,0,331,1
+10,Sun,2021-11-14,4:05PM,Minnesota Vikings,@,Los Angeles Chargers,boxscore,27,20,381,1,253,1
+10,Sun,2021-11-14,4:05PM,Carolina Panthers,@,Arizona Cardinals,boxscore,34,10,341,2,169,2
+10,Sun,2021-11-14,4:25PM,Philadelphia Eagles,@,Denver Broncos,boxscore,30,13,386,1,308,1
+10,Sun,2021-11-14,4:25PM,Green Bay Packers,,Seattle Seahawks,boxscore,17,0,393,1,208,2
+10,Sun,2021-11-14,8:20PM,Kansas City Chiefs,@,Las Vegas Raiders,boxscore,41,14,516,1,299,2
+10,Mon,2021-11-15,8:15PM,San Francisco 49ers,,Los Angeles Rams,boxscore,31,10,335,0,278,2
+11,Thu,2021-11-18,8:20PM,New England Patriots,@,Atlanta Falcons,boxscore,25,0,308,1,165,4
+11,Sun,2021-11-21,1:00PM,Indianapolis Colts,@,Buffalo Bills,boxscore,41,15,370,0,311,4
+11,Sun,2021-11-21,1:00PM,Baltimore Ravens,@,Chicago Bears,boxscore,16,13,299,1,353,1
+11,Sun,2021-11-21,1:00PM,Houston Texans,@,Tennessee Titans,boxscore,22,13,190,0,420,5
+11,Sun,2021-11-21,1:00PM,San Francisco 49ers,@,Jacksonville Jaguars,boxscore,30,10,333,0,200,2
+11,Sun,2021-11-21,1:00PM,Philadelphia Eagles,,New Orleans Saints,boxscore,40,29,380,1,323,3
+11,Sun,2021-11-21,1:00PM,Washington Football Team,@,Carolina Panthers,boxscore,27,21,369,1,297,0
+11,Sun,2021-11-21,1:00PM,Cleveland Browns,,Detroit Lions,boxscore,13,10,349,2,245,2
+11,Sun,2021-11-21,1:00PM,Minnesota Vikings,,Green Bay Packers,boxscore,34,31,408,0,467,0
+11,Sun,2021-11-21,1:00PM,Miami Dolphins,@,New York Jets,boxscore,24,17,388,1,380,1
+11,Sun,2021-11-21,4:05PM,Cincinnati Bengals,@,Las Vegas Raiders,boxscore,32,13,288,1,278,2
+11,Sun,2021-11-21,4:25PM,Kansas City Chiefs,,Dallas Cowboys,boxscore,19,9,370,2,276,3
+11,Sun,2021-11-21,4:25PM,Arizona Cardinals,@,Seattle Seahawks,boxscore,23,13,413,0,266,0
+11,Sun,2021-11-21,8:20PM,Los Angeles Chargers,,Pittsburgh Steelers,boxscore,41,37,533,1,300,0
+11,Mon,2021-11-22,8:15PM,Tampa Bay Buccaneers,,New York Giants,boxscore,30,10,402,1,215,3
+12,Thu,2021-11-25,12:30PM,Chicago Bears,@,Detroit Lions,boxscore,16,14,378,1,239,1
+12,Thu,2021-11-25,4:30PM,Las Vegas Raiders,@,Dallas Cowboys,boxscore,36,33,509,0,437,0
+12,Thu,2021-11-25,8:20PM,Buffalo Bills,@,New Orleans Saints,boxscore,31,6,361,2,190,1
+12,Sun,2021-11-28,1:00PM,Atlanta Falcons,@,Jacksonville Jaguars,boxscore,21,14,332,1,357,2
+12,Sun,2021-11-28,1:00PM,Cincinnati Bengals,,Pittsburgh Steelers,boxscore,41,10,370,1,301,3
+12,Sun,2021-11-28,1:00PM,New York Jets,@,Houston Texans,boxscore,21,14,266,1,202,1
+12,Sun,2021-11-28,1:00PM,New York Giants,,Philadelphia Eagles,boxscore,13,7,264,0,332,4
+12,Sun,2021-11-28,1:00PM,Miami Dolphins,,Carolina Panthers,boxscore,33,10,315,1,198,3
+12,Sun,2021-11-28,1:00PM,Tampa Bay Buccaneers,@,Indianapolis Colts,boxscore,38,31,359,2,392,5
+12,Sun,2021-11-28,1:00PM,New England Patriots,,Tennessee Titans,boxscore,36,13,394,0,355,4
+12,Sun,2021-11-28,4:05PM,Denver Broncos,,Los Angeles Chargers,boxscore,28,13,302,1,357,2
+12,Sun,2021-11-28,4:25PM,San Francisco 49ers,,Minnesota Vikings,boxscore,34,26,423,1,323,2
+12,Sun,2021-11-28,4:25PM,Green Bay Packers,,Los Angeles Rams,boxscore,36,28,399,1,353,3
+12,Sun,2021-11-28,8:20PM,Baltimore Ravens,,Cleveland Browns,boxscore,16,10,303,4,262,2
+12,Mon,2021-11-29,8:15PM,Washington Football Team,,Seattle Seahawks,boxscore,17,15,371,1,267,1
+13,Thu,2021-12-02,8:20PM,Dallas Cowboys,@,New Orleans Saints,boxscore,27,17,377,1,405,4
+13,Sun,2021-12-05,1:00PM,Tampa Bay Buccaneers,@,Atlanta Falcons,boxscore,30,17,425,1,380,1
+13,Sun,2021-12-05,1:00PM,Arizona Cardinals,@,Chicago Bears,boxscore,33,22,257,0,329,4
+13,Sun,2021-12-05,1:00PM,Los Angeles Chargers,@,Cincinnati Bengals,boxscore,41,22,363,3,356,4
+13,Sun,2021-12-05,1:00PM,Detroit Lions,,Minnesota Vikings,boxscore,29,27,372,2,426,1
+13,Sun,2021-12-05,1:00PM,Philadelphia Eagles,@,New York Jets,boxscore,33,18,418,0,281,1
+13,Sun,2021-12-05,1:00PM,Indianapolis Colts,@,Houston Texans,boxscore,31,0,389,1,141,2
+13,Sun,2021-12-05,1:00PM,Miami Dolphins,,New York Giants,boxscore,20,9,297,0,250,1
+13,Sun,2021-12-05,4:00PM,Seattle Seahawks,,San Francisco 49ers,boxscore,30,23,327,3,365,3
+13,Sun,2021-12-05,4:05PM,Washington Football Team,@,Las Vegas Raiders,boxscore,17,15,298,1,310,0
+13,Sun,2021-12-05,4:25PM,Los Angeles Rams,,Jacksonville Jaguars,boxscore,37,7,418,0,197,2
+13,Sun,2021-12-05,4:25PM,Pittsburgh Steelers,,Baltimore Ravens,boxscore,20,19,321,0,326,1
+13,Sun,2021-12-05,8:20PM,Kansas City Chiefs,,Denver Broncos,boxscore,22,9,267,1,404,3
+13,Mon,2021-12-06,8:15PM,New England Patriots,@,Buffalo Bills,boxscore,14,10,241,1,230,1
+14,Thu,2021-12-09,8:20PM,Minnesota Vikings,,Pittsburgh Steelers,boxscore,36,28,458,2,375,1
+14,Sun,2021-12-12,1:00PM,Atlanta Falcons,@,Carolina Panthers,boxscore,29,21,318,1,334,3
+14,Sun,2021-12-12,1:00PM,San Francisco 49ers,@,Cincinnati Bengals,boxscore,26,23,355,0,397,2
+14,Sun,2021-12-12,1:00PM,Cleveland Browns,,Baltimore Ravens,boxscore,24,22,290,1,389,2
+14,Sun,2021-12-12,1:00PM,Dallas Cowboys,@,Washington Football Team,boxscore,27,20,323,2,224,4
+14,Sun,2021-12-12,1:00PM,Seattle Seahawks,@,Houston Texans,boxscore,33,13,453,0,380,0
+14,Sun,2021-12-12,1:00PM,Tennessee Titans,,Jacksonville Jaguars,boxscore,20,0,263,0,192,4
+14,Sun,2021-12-12,1:00PM,Kansas City Chiefs,,Las Vegas Raiders,boxscore,48,9,372,0,290,5
+14,Sun,2021-12-12,1:00PM,New Orleans Saints,@,New York Jets,boxscore,30,9,344,0,256,0
+14,Sun,2021-12-12,4:05PM,Denver Broncos,,Detroit Lions,boxscore,38,10,358,0,316,2
+14,Sun,2021-12-12,4:05PM,Los Angeles Chargers,,New York Giants,boxscore,37,21,423,0,316,2
+14,Sun,2021-12-12,4:25PM,Tampa Bay Buccaneers,,Buffalo Bills,boxscore,33,27,488,0,466,1
+14,Sun,2021-12-12,8:20PM,Green Bay Packers,,Chicago Bears,boxscore,45,30,439,0,347,3
+14,Mon,2021-12-13,8:15PM,Los Angeles Rams,@,Arizona Cardinals,boxscore,30,23,356,0,447,2
+15,Thu,2021-12-16,8:20PM,Kansas City Chiefs,@,Los Angeles Chargers,boxscore,34,28,496,2,428,2
+15,Sat,2021-12-18,8:20PM,Indianapolis Colts,,New England Patriots,boxscore,27,17,275,1,365,2
+15,Sun,2021-12-19,1:00PM,Buffalo Bills,,Carolina Panthers,boxscore,31,14,312,1,275,1
+15,Sun,2021-12-19,1:00PM,Detroit Lions,,Arizona Cardinals,boxscore,30,12,338,1,398,1
+15,Sun,2021-12-19,1:00PM,Dallas Cowboys,@,New York Giants,boxscore,21,6,328,1,302,4
+15,Sun,2021-12-19,1:00PM,Green Bay Packers,@,Baltimore Ravens,boxscore,31,30,346,0,354,0
+15,Sun,2021-12-19,1:00PM,Houston Texans,@,Jacksonville Jaguars,boxscore,30,16,281,1,296,0
+15,Sun,2021-12-19,1:00PM,Miami Dolphins,,New York Jets,boxscore,31,24,379,3,228,1
+15,Sun,2021-12-19,1:00PM,Pittsburgh Steelers,,Tennessee Titans,boxscore,19,13,168,0,318,4
+15,Sun,2021-12-19,4:05PM,San Francisco 49ers,,Atlanta Falcons,boxscore,31,13,397,1,275,1
+15,Sun,2021-12-19,4:05PM,Cincinnati Bengals,@,Denver Broncos,boxscore,15,10,249,0,292,1
+15,Sun,2021-12-19,8:20PM,New Orleans Saints,@,Tampa Bay Buccaneers,boxscore,9,0,212,0,302,2
+15,Mon,2021-12-20,5:00PM,Las Vegas Raiders,@,Cleveland Browns,boxscore,16,14,328,2,236,0
+15,Mon,2021-12-20,8:15PM,Minnesota Vikings,@,Chicago Bears,boxscore,17,9,193,1,370,3
+15,Tue,2021-12-21,7:00PM,Philadelphia Eagles,,Washington Football Team,boxscore,27,17,519,2,237,0
+15,Tue,2021-12-21,7:00PM,Los Angeles Rams,,Seattle Seahawks,boxscore,20,10,332,1,214,1
+16,Thu,2021-12-23,8:20PM,Tennessee Titans,,San Francisco 49ers,boxscore,20,17,278,0,389,2
+16,Sat,2021-12-25,4:30PM,Green Bay Packers,,Cleveland Browns,boxscore,24,22,311,0,408,4
+16,Sat,2021-12-25,8:15PM,Indianapolis Colts,@,Arizona Cardinals,boxscore,22,16,346,0,378,0
+16,Sun,2021-12-26,1:00PM,Atlanta Falcons,,Detroit Lions,boxscore,20,16,254,1,338,1
+16,Sun,2021-12-26,1:00PM,Buffalo Bills,@,New England Patriots,boxscore,33,21,428,0,288,2
+16,Sun,2021-12-26,1:00PM,Tampa Bay Buccaneers,@,Carolina Panthers,boxscore,32,6,391,0,273,1
+16,Sun,2021-12-26,1:00PM,Cincinnati Bengals,,Baltimore Ravens,boxscore,41,21,575,0,334,1
+16,Sun,2021-12-26,1:00PM,Houston Texans,,Los Angeles Chargers,boxscore,41,29,437,0,417,3
+16,Sun,2021-12-26,1:00PM,New York Jets,,Jacksonville Jaguars,boxscore,26,21,373,0,384,1
+16,Sun,2021-12-26,1:00PM,Los Angeles Rams,@,Minnesota Vikings,boxscore,30,23,356,3,361,1
+16,Sun,2021-12-26,1:00PM,Philadelphia Eagles,,New York Giants,boxscore,34,10,324,0,192,2
+16,Sun,2021-12-26,4:05PM,Chicago Bears,@,Seattle Seahawks,boxscore,25,24,317,0,331,0
+16,Sun,2021-12-26,4:25PM,Las Vegas Raiders,,Denver Broncos,boxscore,17,13,342,3,158,0
+16,Sun,2021-12-26,4:25PM,Kansas City Chiefs,,Pittsburgh Steelers,boxscore,36,10,381,0,303,3
+16,Sun,2021-12-26,8:20PM,Dallas Cowboys,,Washington Football Team,boxscore,56,14,497,0,257,2
+16,Mon,2021-12-27,8:15PM,Miami Dolphins,@,New Orleans Saints,boxscore,20,3,259,1,164,2
+17,Sun,2022-01-02,1:00PM,Buffalo Bills,,Atlanta Falcons,boxscore,29,15,351,3,265,1
+17,Sun,2022-01-02,1:00PM,New Orleans Saints,,Carolina Panthers,boxscore,18,10,280,0,178,2
+17,Sun,2022-01-02,1:00PM,Chicago Bears,,New York Giants,boxscore,29,3,249,2,155,4
+17,Sun,2022-01-02,1:00PM,Cincinnati Bengals,,Kansas City Chiefs,boxscore,34,31,475,0,414,0
+17,Sun,2022-01-02,1:00PM,Las Vegas Raiders,@,Indianapolis Colts,boxscore,23,20,326,2,262,0
+17,Sun,2022-01-02,1:00PM,New England Patriots,,Jacksonville Jaguars,boxscore,50,10,471,0,253,3
+17,Sun,2022-01-02,1:00PM,Tennessee Titans,,Miami Dolphins,boxscore,34,3,308,0,256,2
+17,Sun,2022-01-02,1:00PM,Tampa Bay Buccaneers,@,New York Jets,boxscore,28,24,467,1,374,1
+17,Sun,2022-01-02,1:00PM,Philadelphia Eagles,@,Washington Football Team,boxscore,20,16,330,0,312,1
+17,Sun,2022-01-02,4:05PM,Los Angeles Chargers,,Denver Broncos,boxscore,34,13,341,0,319,1
+17,Sun,2022-01-02,4:05PM,San Francisco 49ers,,Houston Texans,boxscore,23,7,416,1,222,1
+17,Sun,2022-01-02,4:25PM,Arizona Cardinals,@,Dallas Cowboys,boxscore,25,22,399,0,301,1
+17,Sun,2022-01-02,4:25PM,Seattle Seahawks,,Detroit Lions,boxscore,51,29,497,0,357,3
+17,Sun,2022-01-02,4:25PM,Los Angeles Rams,@,Baltimore Ravens,boxscore,20,19,373,3,327,2
+17,Sun,2022-01-02,8:20PM,Green Bay Packers,,Minnesota Vikings,boxscore,37,10,481,0,206,0
+17,Mon,2022-01-03,8:15PM,Pittsburgh Steelers,,Cleveland Browns,boxscore,26,14,299,1,232,2
+18,Sat,2022-01-08,4:30PM,Kansas City Chiefs,@,Denver Broncos,boxscore,28,24,390,0,364,1
+18,Sat,2022-01-08,8:15PM,Dallas Cowboys,@,Philadelphia Eagles,boxscore,51,26,475,0,315,1
+18,Sun,2022-01-09,1:00PM,New Orleans Saints,@,Atlanta Falcons,boxscore,30,20,369,0,257,3
+18,Sun,2022-01-09,1:00PM,Tampa Bay Buccaneers,,Carolina Panthers,boxscore,41,17,409,0,317,2
+18,Sun,2022-01-09,1:00PM,Minnesota Vikings,,Chicago Bears,boxscore,31,17,331,0,356,2
+18,Sun,2022-01-09,1:00PM,Cleveland Browns,,Cincinnati Bengals,boxscore,21,16,376,2,182,0
+18,Sun,2022-01-09,1:00PM,Jacksonville Jaguars,,Indianapolis Colts,boxscore,26,11,318,0,233,2
+18,Sun,2022-01-09,1:00PM,Detroit Lions,,Green Bay Packers,boxscore,37,30,404,0,378,3
+18,Sun,2022-01-09,1:00PM,Tennessee Titans,@,Houston Texans,boxscore,28,25,405,0,353,0
+18,Sun,2022-01-09,1:00PM,Miami Dolphins,,New England Patriots,boxscore,33,24,298,0,379,3
+18,Sun,2022-01-09,1:00PM,Washington Football Team,@,New York Giants,boxscore,22,7,325,0,177,3
+18,Sun,2022-01-09,1:00PM,Pittsburgh Steelers,@,Baltimore Ravens,boxscore,16,13,314,1,381,3
+18,Sun,2022-01-09,4:25PM,Buffalo Bills,,New York Jets,boxscore,27,10,424,0,53,0
+18,Sun,2022-01-09,4:25PM,Seattle Seahawks,@,Arizona Cardinals,boxscore,38,30,431,2,305,1
+18,Sun,2022-01-09,4:25PM,San Francisco 49ers,@,Los Angeles Rams,boxscore,27,24,449,2,265,2
+18,Sun,2022-01-09,8:25PM,Las Vegas Raiders,,Los Angeles Chargers,boxscore,35,32,346,0,440,2

--- a/datasets/win-loss-score-2022-season.csv
+++ b/datasets/win-loss-score-2022-season.csv
@@ -1,0 +1,272 @@
+Week,Day,Date,Time,Winner/tie,,Loser/tie,,PtsW,PtsL,YdsW,TOW,YdsL,TOL
+1,Thu,2022-09-08,8:20PM,Buffalo Bills,@,Los Angeles Rams,boxscore,31,10,413,4,243,3
+1,Sun,2022-09-11,1:00PM,New Orleans Saints,@,Atlanta Falcons,boxscore,27,26,385,1,416,2
+1,Sun,2022-09-11,1:00PM,Cleveland Browns,@,Carolina Panthers,boxscore,26,24,355,0,261,1
+1,Sun,2022-09-11,1:00PM,Chicago Bears,,San Francisco 49ers,boxscore,19,10,204,1,331,2
+1,Sun,2022-09-11,1:00PM,Pittsburgh Steelers,@,Cincinnati Bengals,boxscore,23,20,267,0,432,5
+1,Sun,2022-09-11,1:00PM,Houston Texans,,Indianapolis Colts,boxscore,20,20,299,1,517,2
+1,Sun,2022-09-11,1:00PM,Philadelphia Eagles,@,Detroit Lions,boxscore,38,35,455,0,386,1
+1,Sun,2022-09-11,1:00PM,Washington Commanders,,Jacksonville Jaguars,boxscore,28,22,390,3,383,1
+1,Sun,2022-09-11,1:00PM,Miami Dolphins,,New England Patriots,boxscore,20,7,307,0,271,3
+1,Sun,2022-09-11,1:00PM,Baltimore Ravens,@,New York Jets,boxscore,24,9,274,1,380,2
+1,Sun,2022-09-11,4:25PM,Kansas City Chiefs,@,Arizona Cardinals,boxscore,44,21,488,1,282,0
+1,Sun,2022-09-11,4:25PM,Minnesota Vikings,,Green Bay Packers,boxscore,23,7,395,0,338,2
+1,Sun,2022-09-11,4:25PM,New York Giants,@,Tennessee Titans,boxscore,21,20,394,2,359,1
+1,Sun,2022-09-11,4:25PM,Los Angeles Chargers,,Las Vegas Raiders,boxscore,24,19,355,0,320,3
+1,Sun,2022-09-11,8:20PM,Tampa Bay Buccaneers,@,Dallas Cowboys,boxscore,19,3,347,1,244,1
+1,Mon,2022-09-12,8:20PM,Seattle Seahawks,,Denver Broncos,boxscore,17,16,253,1,433,2
+2,Thu,2022-09-15,8:15PM,Kansas City Chiefs,,Los Angeles Chargers,boxscore,27,24,319,0,401,1
+2,Sun,2022-09-18,1:00PM,New York Giants,,Carolina Panthers,boxscore,19,16,265,0,275,2
+2,Sun,2022-09-18,1:00PM,New York Jets,@,Cleveland Browns,boxscore,31,30,402,1,405,1
+2,Sun,2022-09-18,1:00PM,Jacksonville Jaguars,,Indianapolis Colts,boxscore,24,0,331,0,218,3
+2,Sun,2022-09-18,1:00PM,Detroit Lions,,Washington Commanders,boxscore,36,27,425,0,396,1
+2,Sun,2022-09-18,1:00PM,Miami Dolphins,@,Baltimore Ravens,boxscore,42,38,547,2,473,0
+2,Sun,2022-09-18,1:00PM,Tampa Bay Buccaneers,@,New Orleans Saints,boxscore,20,10,260,1,308,5
+2,Sun,2022-09-18,1:00PM,New England Patriots,@,Pittsburgh Steelers,boxscore,17,14,376,1,243,2
+2,Sun,2022-09-18,4:05PM,Los Angeles Rams,,Atlanta Falcons,boxscore,31,27,337,3,261,3
+2,Sun,2022-09-18,4:05PM,San Francisco 49ers,,Seattle Seahawks,boxscore,27,7,373,0,216,3
+2,Sun,2022-09-18,4:25PM,Dallas Cowboys,,Cincinnati Bengals,boxscore,20,17,337,1,254,0
+2,Sun,2022-09-18,4:25PM,Arizona Cardinals,@,Las Vegas Raiders,boxscore,29,23,413,1,324,1
+2,Sun,2022-09-18,4:25PM,Denver Broncos,,Houston Texans,boxscore,16,9,350,1,234,0
+2,Sun,2022-09-18,8:20PM,Green Bay Packers,,Chicago Bears,boxscore,27,10,414,1,228,1
+2,Mon,2022-09-19,7:15PM,Buffalo Bills,,Tennessee Titans,boxscore,41,7,414,0,187,4
+2,Mon,2022-09-19,8:30PM,Philadelphia Eagles,,Minnesota Vikings,boxscore,24,7,486,1,264,3
+3,Thu,2022-09-22,8:15PM,Cleveland Browns,,Pittsburgh Steelers,boxscore,29,17,376,0,308,1
+3,Sun,2022-09-25,1:00PM,Miami Dolphins,,Buffalo Bills,boxscore,21,19,212,0,497,1
+3,Sun,2022-09-25,1:00PM,Carolina Panthers,,New Orleans Saints,boxscore,22,14,293,0,426,3
+3,Sun,2022-09-25,1:00PM,Chicago Bears,,Houston Texans,boxscore,23,20,363,2,329,2
+3,Sun,2022-09-25,1:00PM,Cincinnati Bengals,@,New York Jets,boxscore,27,12,330,1,328,4
+3,Sun,2022-09-25,1:00PM,Indianapolis Colts,,Kansas City Chiefs,boxscore,20,17,259,1,315,2
+3,Sun,2022-09-25,1:00PM,Minnesota Vikings,,Detroit Lions,boxscore,28,24,373,1,416,1
+3,Sun,2022-09-25,1:00PM,Baltimore Ravens,@,New England Patriots,boxscore,37,26,394,2,447,4
+3,Sun,2022-09-25,1:00PM,Tennessee Titans,,Las Vegas Raiders,boxscore,24,22,361,1,396,1
+3,Sun,2022-09-25,1:00PM,Philadelphia Eagles,@,Washington Commanders,boxscore,24,8,400,0,240,1
+3,Sun,2022-09-25,4:05PM,Jacksonville Jaguars,@,Los Angeles Chargers,boxscore,38,10,413,0,312,2
+3,Sun,2022-09-25,4:25PM,Atlanta Falcons,@,Seattle Seahawks,boxscore,27,23,386,2,420,1
+3,Sun,2022-09-25,4:25PM,Los Angeles Rams,@,Arizona Cardinals,boxscore,20,12,339,1,365,0
+3,Sun,2022-09-25,4:25PM,Green Bay Packers,@,Tampa Bay Buccaneers,boxscore,14,12,315,2,285,2
+3,Sun,2022-09-25,8:20PM,Denver Broncos,,San Francisco 49ers,boxscore,11,10,261,0,267,3
+3,Mon,2022-09-26,8:15PM,Dallas Cowboys,@,New York Giants,boxscore,23,16,391,0,336,1
+4,Thu,2022-09-29,8:15PM,Cincinnati Bengals,,Miami Dolphins,boxscore,27,15,371,0,378,2
+4,Sun,2022-10-02,9:30AM,Minnesota Vikings,@,New Orleans Saints,boxscore,28,25,344,1,338,2
+4,Sun,2022-10-02,1:00PM,Atlanta Falcons,,Cleveland Browns,boxscore,23,20,333,1,403,2
+4,Sun,2022-10-02,1:00PM,Buffalo Bills,@,Baltimore Ravens,boxscore,23,20,326,2,296,2
+4,Sun,2022-10-02,1:00PM,New York Giants,,Chicago Bears,boxscore,20,12,333,2,304,3
+4,Sun,2022-10-02,1:00PM,Tennessee Titans,@,Indianapolis Colts,boxscore,24,17,243,0,365,3
+4,Sun,2022-10-02,1:00PM,Dallas Cowboys,,Washington Commanders,boxscore,25,10,279,0,297,2
+4,Sun,2022-10-02,1:00PM,Seattle Seahawks,@,Detroit Lions,boxscore,48,45,555,1,520,2
+4,Sun,2022-10-02,1:00PM,Los Angeles Chargers,@,Houston Texans,boxscore,34,24,419,1,346,2
+4,Sun,2022-10-02,1:00PM,Philadelphia Eagles,,Jacksonville Jaguars,boxscore,29,21,401,1,219,5
+4,Sun,2022-10-02,1:00PM,New York Jets,@,Pittsburgh Steelers,boxscore,24,20,348,2,297,4
+4,Sun,2022-10-02,4:05PM,Arizona Cardinals,@,Carolina Panthers,boxscore,26,16,338,1,220,3
+4,Sun,2022-10-02,4:25PM,Las Vegas Raiders,,Denver Broncos,boxscore,32,23,385,0,299,1
+4,Sun,2022-10-02,4:25PM,Green Bay Packers,,New England Patriots,boxscore,27,24,443,2,271,1
+4,Sun,2022-10-02,8:20PM,Kansas City Chiefs,@,Tampa Bay Buccaneers,boxscore,41,31,417,1,376,2
+4,Mon,2022-10-03,8:15PM,San Francisco 49ers,,Los Angeles Rams,boxscore,24,9,327,0,257,2
+5,Thu,2022-10-06,8:15PM,Indianapolis Colts,@,Denver Broncos,boxscore,12,9,306,2,375,2
+5,Sun,2022-10-09,9:30AM,New York Giants,@,Green Bay Packers,boxscore,27,22,338,0,301,0
+5,Sun,2022-10-09,1:00PM,Tampa Bay Buccaneers,,Atlanta Falcons,boxscore,21,15,420,0,261,0
+5,Sun,2022-10-09,1:00PM,Buffalo Bills,,Pittsburgh Steelers,boxscore,38,3,552,2,364,2
+5,Sun,2022-10-09,1:00PM,Minnesota Vikings,,Chicago Bears,boxscore,29,22,429,1,271,1
+5,Sun,2022-10-09,1:00PM,Los Angeles Chargers,@,Cleveland Browns,boxscore,30,28,465,0,443,1
+5,Sun,2022-10-09,1:00PM,New England Patriots,,Detroit Lions,boxscore,29,0,364,1,312,2
+5,Sun,2022-10-09,1:00PM,Houston Texans,@,Jacksonville Jaguars,boxscore,13,6,248,0,422,2
+5,Sun,2022-10-09,1:00PM,New York Jets,,Miami Dolphins,boxscore,40,17,322,0,295,2
+5,Sun,2022-10-09,1:00PM,New Orleans Saints,,Seattle Seahawks,boxscore,39,32,438,2,396,1
+5,Sun,2022-10-09,1:00PM,Tennessee Titans,@,Washington Commanders,boxscore,21,17,241,0,385,1
+5,Sun,2022-10-09,4:05PM,San Francisco 49ers,@,Carolina Panthers,boxscore,37,15,397,1,308,1
+5,Sun,2022-10-09,4:25PM,Philadelphia Eagles,@,Arizona Cardinals,boxscore,20,17,357,0,363,1
+5,Sun,2022-10-09,4:25PM,Dallas Cowboys,@,Los Angeles Rams,boxscore,22,10,239,0,323,3
+5,Sun,2022-10-09,8:20PM,Baltimore Ravens,,Cincinnati Bengals,boxscore,19,17,325,1,291,1
+5,Mon,2022-10-10,8:15PM,Kansas City Chiefs,,Las Vegas Raiders,boxscore,30,29,368,0,378,0
+6,Thu,2022-10-13,8:15PM,Washington Commanders,@,Chicago Bears,boxscore,12,7,214,0,391,2
+6,Sun,2022-10-16,1:00PM,Atlanta Falcons,,San Francisco 49ers,boxscore,28,14,289,0,346,3
+6,Sun,2022-10-16,1:00PM,Cincinnati Bengals,@,New Orleans Saints,boxscore,30,26,348,1,399,0
+6,Sun,2022-10-16,1:00PM,New England Patriots,@,Cleveland Browns,boxscore,38,15,399,1,328,4
+6,Sun,2022-10-16,1:00PM,Indianapolis Colts,,Jacksonville Jaguars,boxscore,34,27,434,0,379,1
+6,Sun,2022-10-16,1:00PM,New York Jets,@,Green Bay Packers,boxscore,27,10,278,0,278,1
+6,Sun,2022-10-16,1:00PM,Minnesota Vikings,@,Miami Dolphins,boxscore,24,16,234,0,458,3
+6,Sun,2022-10-16,1:00PM,New York Giants,,Baltimore Ravens,boxscore,24,20,238,1,406,2
+6,Sun,2022-10-16,1:00PM,Pittsburgh Steelers,,Tampa Bay Buccaneers,boxscore,20,18,270,0,304,0
+6,Sun,2022-10-16,4:05PM,Los Angeles Rams,,Carolina Panthers,boxscore,24,10,360,1,203,1
+6,Sun,2022-10-16,4:05PM,Seattle Seahawks,,Arizona Cardinals,boxscore,19,9,296,1,315,2
+6,Sun,2022-10-16,4:25PM,Buffalo Bills,@,Kansas City Chiefs,boxscore,24,20,443,1,387,2
+6,Sun,2022-10-16,8:20PM,Philadelphia Eagles,,Dallas Cowboys,boxscore,26,17,268,0,315,3
+6,Mon,2022-10-17,8:15PM,Los Angeles Chargers,,Denver Broncos,boxscore,19,16,297,1,258,1
+7,Thu,2022-10-20,8:15PM,Arizona Cardinals,,New Orleans Saints,boxscore,42,34,326,0,494,3
+7,Sun,2022-10-23,1:00PM,Cincinnati Bengals,,Atlanta Falcons,boxscore,35,17,537,0,214,0
+7,Sun,2022-10-23,1:00PM,Carolina Panthers,,Tampa Bay Buccaneers,boxscore,21,3,343,0,322,0
+7,Sun,2022-10-23,1:00PM,Baltimore Ravens,,Cleveland Browns,boxscore,23,20,254,1,336,2
+7,Sun,2022-10-23,1:00PM,Tennessee Titans,,Indianapolis Colts,boxscore,19,10,254,1,292,3
+7,Sun,2022-10-23,1:00PM,Dallas Cowboys,,Detroit Lions,boxscore,24,6,330,1,312,5
+7,Sun,2022-10-23,1:00PM,Washington Commanders,,Green Bay Packers,boxscore,23,21,364,1,232,1
+7,Sun,2022-10-23,1:00PM,New York Giants,@,Jacksonville Jaguars,boxscore,23,17,436,0,452,1
+7,Sun,2022-10-23,4:05PM,Las Vegas Raiders,,Houston Texans,boxscore,38,20,400,0,404,1
+7,Sun,2022-10-23,4:05PM,New York Jets,@,Denver Broncos,boxscore,16,9,260,0,324,1
+7,Sun,2022-10-23,4:25PM,Kansas City Chiefs,@,San Francisco 49ers,boxscore,44,23,529,2,444,3
+7,Sun,2022-10-23,4:25PM,Seattle Seahawks,@,Los Angeles Chargers,boxscore,37,23,404,2,329,2
+7,Sun,2022-10-23,8:20PM,Miami Dolphins,,Pittsburgh Steelers,boxscore,16,10,372,0,341,3
+7,Mon,2022-10-24,8:15PM,Chicago Bears,@,New England Patriots,boxscore,33,14,390,1,260,4
+8,Thu,2022-10-27,8:15PM,Baltimore Ravens,@,Tampa Bay Buccaneers,boxscore,27,22,453,0,349,1
+8,Sun,2022-10-30,9:30AM,Denver Broncos,@,Jacksonville Jaguars,boxscore,21,17,331,1,305,2
+8,Sun,2022-10-30,1:00PM,Miami Dolphins,@,Detroit Lions,boxscore,31,27,476,1,393,0
+8,Sun,2022-10-30,1:00PM,Philadelphia Eagles,,Pittsburgh Steelers,boxscore,35,13,401,0,302,2
+8,Sun,2022-10-30,1:00PM,Atlanta Falcons,,Carolina Panthers,boxscore,37,34,406,2,478,1
+8,Sun,2022-10-30,1:00PM,Dallas Cowboys,,Chicago Bears,boxscore,49,29,442,1,371,1
+8,Sun,2022-10-30,1:00PM,Minnesota Vikings,,Arizona Cardinals,boxscore,34,26,381,1,375,3
+8,Sun,2022-10-30,1:00PM,New Orleans Saints,,Las Vegas Raiders,boxscore,24,0,367,0,183,1
+8,Sun,2022-10-30,1:00PM,New England Patriots,@,New York Jets,boxscore,22,17,288,1,387,3
+8,Sun,2022-10-30,4:05PM,Tennessee Titans,@,Houston Texans,boxscore,17,10,354,2,161,1
+8,Sun,2022-10-30,4:25PM,San Francisco 49ers,@,Los Angeles Rams,boxscore,31,14,368,0,223,0
+8,Sun,2022-10-30,4:25PM,Washington Commanders,@,Indianapolis Colts,boxscore,17,16,362,1,324,2
+8,Sun,2022-10-30,4:25PM,Seattle Seahawks,,New York Giants,boxscore,27,13,277,1,225,2
+8,Sun,2022-10-30,8:20PM,Buffalo Bills,,Green Bay Packers,boxscore,27,17,369,2,398,1
+8,Mon,2022-10-31,8:15PM,Cleveland Browns,,Cincinnati Bengals,boxscore,32,13,440,2,229,2
+9,Thu,2022-11-03,8:15PM,Philadelphia Eagles,@,Houston Texans,boxscore,29,17,360,1,303,2
+9,Sun,2022-11-06,1:00PM,New York Jets,,Buffalo Bills,boxscore,20,17,310,1,317,2
+9,Sun,2022-11-06,1:00PM,Detroit Lions,,Green Bay Packers,boxscore,15,9,254,1,389,3
+9,Sun,2022-11-06,1:00PM,Minnesota Vikings,@,Washington Commanders,boxscore,20,17,301,1,263,1
+9,Sun,2022-11-06,1:00PM,Los Angeles Chargers,@,Atlanta Falcons,boxscore,20,17,336,2,315,2
+9,Sun,2022-11-06,1:00PM,Cincinnati Bengals,,Carolina Panthers,boxscore,42,21,464,0,228,3
+9,Sun,2022-11-06,1:00PM,Miami Dolphins,@,Chicago Bears,boxscore,35,32,379,0,368,0
+9,Sun,2022-11-06,1:00PM,New England Patriots,,Indianapolis Colts,boxscore,26,3,203,1,121,1
+9,Sun,2022-11-06,1:00PM,Jacksonville Jaguars,,Las Vegas Raiders,boxscore,27,20,403,1,321,1
+9,Sun,2022-11-06,4:05PM,Seattle Seahawks,@,Arizona Cardinals,boxscore,31,21,421,1,262,1
+9,Sun,2022-11-06,4:25PM,Tampa Bay Buccaneers,,Los Angeles Rams,boxscore,16,13,323,0,206,0
+9,Sun,2022-11-06,8:20PM,Kansas City Chiefs,,Tennessee Titans,boxscore,20,17,499,1,229,0
+9,Mon,2022-11-07,8:15PM,Baltimore Ravens,@,New Orleans Saints,boxscore,27,13,319,0,243,1
+10,Thu,2022-11-10,8:15PM,Carolina Panthers,,Atlanta Falcons,boxscore,25,15,333,0,291,1
+10,Sun,2022-11-13,9:30AM,Tampa Bay Buccaneers,,Seattle Seahawks,boxscore,21,16,419,2,283,1
+10,Sun,2022-11-13,1:00PM,Minnesota Vikings,@,Buffalo Bills,boxscore,33,30,481,2,486,4
+10,Sun,2022-11-13,1:00PM,Miami Dolphins,,Cleveland Browns,boxscore,39,17,491,0,297,1
+10,Sun,2022-11-13,1:00PM,Tennessee Titans,,Denver Broncos,boxscore,17,10,307,1,313,1
+10,Sun,2022-11-13,1:00PM,New York Giants,,Houston Texans,boxscore,24,16,367,0,387,2
+10,Sun,2022-11-13,1:00PM,Detroit Lions,@,Chicago Bears,boxscore,31,30,323,0,408,1
+10,Sun,2022-11-13,1:00PM,Kansas City Chiefs,,Jacksonville Jaguars,boxscore,27,17,486,3,315,0
+10,Sun,2022-11-13,1:00PM,Pittsburgh Steelers,,New Orleans Saints,boxscore,20,10,379,0,186,2
+10,Sun,2022-11-13,4:05PM,Indianapolis Colts,@,Las Vegas Raiders,boxscore,25,20,415,1,309,0
+10,Sun,2022-11-13,4:25PM,Green Bay Packers,,Dallas Cowboys,boxscore,31,28,415,2,421,2
+10,Sun,2022-11-13,4:25PM,Arizona Cardinals,@,Los Angeles Rams,boxscore,27,17,298,0,256,2
+10,Sun,2022-11-13,8:20PM,San Francisco 49ers,,Los Angeles Chargers,boxscore,22,16,387,1,238,1
+10,Mon,2022-11-14,8:15PM,Washington Commanders,@,Philadelphia Eagles,boxscore,32,21,330,2,264,4
+11,Thu,2022-11-17,8:15PM,Tennessee Titans,@,Green Bay Packers,boxscore,27,17,408,1,271,0
+11,Sun,2022-11-20,1:00PM,Buffalo Bills,,Cleveland Browns,boxscore,31,23,357,0,396,1
+11,Sun,2022-11-20,1:00PM,Detroit Lions,@,New York Giants,boxscore,31,18,325,0,413,3
+11,Sun,2022-11-20,1:00PM,Washington Commanders,@,Houston Texans,boxscore,23,10,344,0,148,2
+11,Sun,2022-11-20,1:00PM,New England Patriots,,New York Jets,boxscore,10,3,297,0,103,0
+11,Sun,2022-11-20,1:00PM,Atlanta Falcons,,Chicago Bears,boxscore,27,24,280,2,288,1
+11,Sun,2022-11-20,1:00PM,Baltimore Ravens,,Carolina Panthers,boxscore,13,3,308,1,205,3
+11,Sun,2022-11-20,1:00PM,Philadelphia Eagles,@,Indianapolis Colts,boxscore,17,16,314,2,284,1
+11,Sun,2022-11-20,1:00PM,New Orleans Saints,,Los Angeles Rams,boxscore,27,20,323,0,336,0
+11,Sun,2022-11-20,4:05PM,Las Vegas Raiders,@,Denver Broncos,boxscore,22,16,407,0,320,0
+11,Sun,2022-11-20,4:25PM,Cincinnati Bengals,@,Pittsburgh Steelers,boxscore,37,30,408,2,351,0
+11,Sun,2022-11-20,4:25PM,Dallas Cowboys,@,Minnesota Vikings,boxscore,40,3,458,0,183,1
+11,Sun,2022-11-20,8:20PM,Kansas City Chiefs,@,Los Angeles Chargers,boxscore,30,27,485,1,365,2
+11,Mon,2022-11-21,8:15PM,San Francisco 49ers,@,Arizona Cardinals,boxscore,38,10,387,0,314,2
+12,Thu,2022-11-24,12:30PM,Buffalo Bills,@,Detroit Lions,boxscore,28,25,401,1,326,2
+12,Thu,2022-11-24,4:30PM,Dallas Cowboys,,New York Giants,boxscore,28,20,430,2,300,0
+12,Thu,2022-11-24,8:20PM,Minnesota Vikings,,New England Patriots,boxscore,33,26,358,1,409,0
+12,Sun,2022-11-27,1:00PM,Cincinnati Bengals,@,Tennessee Titans,boxscore,20,16,374,0,344,0
+12,Sun,2022-11-27,1:00PM,Cleveland Browns,,Tampa Bay Buccaneers,boxscore,23,17,367,1,325,0
+12,Sun,2022-11-27,1:00PM,Miami Dolphins,,Houston Texans,boxscore,30,15,339,1,210,3
+12,Sun,2022-11-27,1:00PM,Jacksonville Jaguars,,Baltimore Ravens,boxscore,28,27,332,1,415,2
+12,Sun,2022-11-27,1:00PM,Washington Commanders,,Atlanta Falcons,boxscore,19,13,314,1,332,1
+12,Sun,2022-11-27,1:00PM,Carolina Panthers,,Denver Broncos,boxscore,23,10,349,1,246,2
+12,Sun,2022-11-27,1:00PM,New York Jets,,Chicago Bears,boxscore,31,10,466,0,292,1
+12,Sun,2022-11-27,4:05PM,Las Vegas Raiders,@,Seattle Seahawks,boxscore,40,34,576,2,372,2
+12,Sun,2022-11-27,4:05PM,Los Angeles Chargers,@,Arizona Cardinals,boxscore,25,24,311,0,366,2
+12,Sun,2022-11-27,4:25PM,Kansas City Chiefs,,Los Angeles Rams,boxscore,26,10,437,2,198,2
+12,Sun,2022-11-27,4:25PM,San Francisco 49ers,,New Orleans Saints,boxscore,13,0,317,0,260,2
+12,Sun,2022-11-27,8:20PM,Philadelphia Eagles,,Green Bay Packers,boxscore,40,33,500,1,342,2
+12,Mon,2022-11-28,8:15PM,Pittsburgh Steelers,@,Indianapolis Colts,boxscore,24,17,323,0,290,2
+13,Thu,2022-12-01,8:15PM,Buffalo Bills,@,New England Patriots,boxscore,24,10,355,1,242,0
+13,Sun,2022-12-04,1:00PM,Cleveland Browns,@,Houston Texans,boxscore,27,14,304,2,283,4
+13,Sun,2022-12-04,1:00PM,Baltimore Ravens,,Denver Broncos,boxscore,10,9,285,2,272,0
+13,Sun,2022-12-04,1:00PM,Detroit Lions,,Jacksonville Jaguars,boxscore,40,14,437,0,266,1
+13,Sun,2022-12-04,1:00PM,Minnesota Vikings,,New York Jets,boxscore,27,22,287,0,486,2
+13,Sun,2022-12-04,1:00PM,Washington Commanders,@,New York Giants,boxscore,20,20,411,1,316,1
+13,Sun,2022-12-04,1:00PM,Philadelphia Eagles,,Tennessee Titans,boxscore,35,10,453,0,209,0
+13,Sun,2022-12-04,1:00PM,Pittsburgh Steelers,@,Atlanta Falcons,boxscore,19,16,351,0,306,1
+13,Sun,2022-12-04,1:00PM,Green Bay Packers,@,Chicago Bears,boxscore,28,19,357,0,409,3
+13,Sun,2022-12-04,4:05PM,San Francisco 49ers,,Miami Dolphins,boxscore,33,17,351,1,308,4
+13,Sun,2022-12-04,4:05PM,Seattle Seahawks,@,Los Angeles Rams,boxscore,27,23,438,2,319,2
+13,Sun,2022-12-04,4:25PM,Cincinnati Bengals,,Kansas City Chiefs,boxscore,27,24,431,0,349,1
+13,Sun,2022-12-04,4:25PM,Las Vegas Raiders,,Los Angeles Chargers,boxscore,27,20,404,2,386,1
+13,Sun,2022-12-04,8:20PM,Dallas Cowboys,,Indianapolis Colts,boxscore,54,19,385,1,309,5
+13,Mon,2022-12-05,8:15PM,Tampa Bay Buccaneers,,New Orleans Saints,boxscore,17,16,350,2,298,0
+14,Thu,2022-12-08,8:15PM,Los Angeles Rams,,Las Vegas Raiders,boxscore,17,16,282,1,302,2
+14,Sun,2022-12-11,1:00PM,Buffalo Bills,,New York Jets,boxscore,20,12,232,0,309,2
+14,Sun,2022-12-11,1:00PM,Cincinnati Bengals,,Cleveland Browns,boxscore,23,10,363,1,344,1
+14,Sun,2022-12-11,1:00PM,Dallas Cowboys,,Houston Texans,boxscore,27,23,404,3,327,2
+14,Sun,2022-12-11,1:00PM,Detroit Lions,,Minnesota Vikings,boxscore,34,23,464,0,416,2
+14,Sun,2022-12-11,1:00PM,Jacksonville Jaguars,@,Tennessee Titans,boxscore,36,22,428,0,364,4
+14,Sun,2022-12-11,1:00PM,Philadelphia Eagles,@,New York Giants,boxscore,48,22,437,0,304,1
+14,Sun,2022-12-11,1:00PM,Baltimore Ravens,@,Pittsburgh Steelers,boxscore,16,14,309,0,329,3
+14,Sun,2022-12-11,4:20PM,Kansas City Chiefs,@,Denver Broncos,boxscore,34,28,431,3,320,2
+14,Sun,2022-12-11,4:25PM,Carolina Panthers,@,Seattle Seahawks,boxscore,30,24,328,0,287,2
+14,Sun,2022-12-11,4:25PM,San Francisco 49ers,,Tampa Bay Buccaneers,boxscore,35,7,404,1,322,3
+14,Sun,2022-12-11,8:20PM,Los Angeles Chargers,,Miami Dolphins,boxscore,23,17,432,0,219,0
+14,Mon,2022-12-12,8:15PM,New England Patriots,@,Arizona Cardinals,boxscore,27,13,328,1,323,2
+15,Thu,2022-12-15,8:15PM,San Francisco 49ers,@,Seattle Seahawks,boxscore,21,13,381,0,277,1
+15,Sat,2022-12-17,1:00PM,Minnesota Vikings,,Indianapolis Colts,boxscore,39,36,518,3,341,1
+15,Sat,2022-12-17,4:30PM,Cleveland Browns,,Baltimore Ravens,boxscore,13,3,283,0,324,2
+15,Sat,2022-12-17,8:15PM,Buffalo Bills,,Miami Dolphins,boxscore,32,29,446,1,405,0
+15,Sun,2022-12-18,1:00PM,New Orleans Saints,,Atlanta Falcons,boxscore,21,18,348,1,320,1
+15,Sun,2022-12-18,1:00PM,Pittsburgh Steelers,@,Carolina Panthers,boxscore,24,16,325,0,209,0
+15,Sun,2022-12-18,1:00PM,Philadelphia Eagles,@,Chicago Bears,boxscore,25,20,421,3,248,1
+15,Sun,2022-12-18,1:00PM,Jacksonville Jaguars,,Dallas Cowboys,boxscore,40,34,503,3,397,2
+15,Sun,2022-12-18,1:00PM,Detroit Lions,@,New York Jets,boxscore,20,17,359,0,337,1
+15,Sun,2022-12-18,1:00PM,Kansas City Chiefs,@,Houston Texans,boxscore,30,24,502,2,219,1
+15,Sun,2022-12-18,4:05PM,Denver Broncos,,Arizona Cardinals,boxscore,24,15,324,2,240,3
+15,Sun,2022-12-18,4:05PM,Las Vegas Raiders,,New England Patriots,boxscore,30,24,308,1,318,1
+15,Sun,2022-12-18,4:25PM,Cincinnati Bengals,@,Tampa Bay Buccaneers,boxscore,34,23,237,1,396,4
+15,Sun,2022-12-18,4:25PM,Los Angeles Chargers,,Tennessee Titans,boxscore,17,14,365,2,284,1
+15,Sun,2022-12-18,8:15PM,New York Giants,@,Washington Commanders,boxscore,20,12,288,0,387,2
+15,Mon,2022-12-19,8:15PM,Green Bay Packers,,Los Angeles Rams,boxscore,24,12,345,2,156,1
+16,Thu,2022-12-22,8:15PM,Jacksonville Jaguars,@,New York Jets,boxscore,19,3,365,1,227,2
+16,Sat,2022-12-24,1:00PM,Baltimore Ravens,,Atlanta Falcons,boxscore,17,9,299,0,327,1
+16,Sat,2022-12-24,1:00PM,Buffalo Bills,@,Chicago Bears,boxscore,35,13,426,3,209,2
+16,Sat,2022-12-24,1:00PM,Carolina Panthers,,Detroit Lions,boxscore,37,23,570,0,381,1
+16,Sat,2022-12-24,1:00PM,Cincinnati Bengals,@,New England Patriots,boxscore,22,18,442,3,285,1
+16,Sat,2022-12-24,1:00PM,New Orleans Saints,@,Cleveland Browns,boxscore,17,10,244,1,249,1
+16,Sat,2022-12-24,1:00PM,Houston Texans,@,Tennessee Titans,boxscore,19,14,285,1,272,3
+16,Sat,2022-12-24,1:00PM,Kansas City Chiefs,,Seattle Seahawks,boxscore,24,10,297,0,333,1
+16,Sat,2022-12-24,1:00PM,Minnesota Vikings,,New York Giants,boxscore,27,24,353,0,445,2
+16,Sat,2022-12-24,4:05PM,San Francisco 49ers,,Washington Commanders,boxscore,37,20,371,1,349,2
+16,Sat,2022-12-24,4:25PM,Dallas Cowboys,,Philadelphia Eagles,boxscore,40,34,419,1,442,4
+16,Sat,2022-12-24,8:15PM,Pittsburgh Steelers,,Las Vegas Raiders,boxscore,13,10,350,1,201,3
+16,Sun,2022-12-25,1:00PM,Green Bay Packers,@,Miami Dolphins,boxscore,26,20,301,1,376,4
+16,Sun,2022-12-25,4:30PM,Los Angeles Rams,,Denver Broncos,boxscore,51,14,388,0,323,4
+16,Sun,2022-12-25,8:20PM,Tampa Bay Buccaneers,@,Arizona Cardinals,boxscore,19,16,396,2,325,3
+16,Mon,2022-12-26,8:15PM,Los Angeles Chargers,@,Indianapolis Colts,boxscore,20,3,314,2,173,3
+17,Thu,2022-12-29,8:15PM,Dallas Cowboys,@,Tennessee Titans,boxscore,27,13,361,3,317,2
+17,Sun,2023-01-01,1:00PM,Atlanta Falcons,,Arizona Cardinals,boxscore,20,19,298,1,339,0
+17,Sun,2023-01-01,1:00PM,Tampa Bay Buccaneers,,Carolina Panthers,boxscore,30,24,478,1,400,3
+17,Sun,2023-01-01,1:00PM,Detroit Lions,,Chicago Bears,boxscore,41,10,504,0,230,2
+17,Sun,2023-01-01,1:00PM,Cleveland Browns,@,Washington Commanders,boxscore,24,10,301,0,260,3
+17,Sun,2023-01-01,1:00PM,New York Giants,,Indianapolis Colts,boxscore,38,10,394,1,252,1
+17,Sun,2023-01-01,1:00PM,Kansas City Chiefs,,Denver Broncos,boxscore,27,24,374,2,307,2
+17,Sun,2023-01-01,1:00PM,Jacksonville Jaguars,@,Houston Texans,boxscore,31,3,337,2,277,1
+17,Sun,2023-01-01,1:00PM,New England Patriots,,Miami Dolphins,boxscore,23,21,249,0,333,2
+17,Sun,2023-01-01,1:00PM,New Orleans Saints,@,Philadelphia Eagles,boxscore,20,10,313,1,313,1
+17,Sun,2023-01-01,4:05PM,Seattle Seahawks,,New York Jets,boxscore,23,6,346,0,279,3
+17,Sun,2023-01-01,4:05PM,San Francisco 49ers,@,Las Vegas Raiders,boxscore,37,34,454,1,500,2
+17,Sun,2023-01-01,4:25PM,Green Bay Packers,,Minnesota Vikings,boxscore,41,17,315,0,346,4
+17,Sun,2023-01-01,4:25PM,Los Angeles Chargers,,Los Angeles Rams,boxscore,31,10,431,0,277,1
+17,Sun,2023-01-01,8:20PM,Pittsburgh Steelers,@,Baltimore Ravens,boxscore,16,13,351,0,240,1
+18,Sat,2023-01-07,4:30PM,Kansas City Chiefs,@,Las Vegas Raiders,boxscore,31,13,349,0,279,2
+18,Sat,2023-01-07,8:15PM,Jacksonville Jaguars,,Tennessee Titans,boxscore,20,16,222,1,312,2
+18,Sun,2023-01-08,1:00PM,Buffalo Bills,,New England Patriots,boxscore,35,23,327,3,341,3
+18,Sun,2023-01-08,1:00PM,Cincinnati Bengals,,Baltimore Ravens,boxscore,27,16,257,1,386,4
+18,Sun,2023-01-08,1:00PM,Atlanta Falcons,,Tampa Bay Buccaneers,boxscore,30,17,382,1,222,1
+18,Sun,2023-01-08,1:00PM,Carolina Panthers,@,New Orleans Saints,boxscore,10,7,203,2,304,1
+18,Sun,2023-01-08,1:00PM,Minnesota Vikings,@,Chicago Bears,boxscore,29,13,482,2,259,2
+18,Sun,2023-01-08,1:00PM,Pittsburgh Steelers,,Cleveland Browns,boxscore,28,14,333,1,307,2
+18,Sun,2023-01-08,1:00PM,Houston Texans,@,Indianapolis Colts,boxscore,32,31,360,3,398,3
+18,Sun,2023-01-08,1:00PM,Miami Dolphins,,New York Jets,boxscore,11,6,302,0,187,0
+18,Sun,2023-01-08,4:25PM,San Francisco 49ers,,Arizona Cardinals,boxscore,38,13,311,0,255,4
+18,Sun,2023-01-08,4:25PM,Washington Commanders,,Dallas Cowboys,boxscore,26,6,309,1,182,2
+18,Sun,2023-01-08,4:25PM,Denver Broncos,,Los Angeles Chargers,boxscore,31,28,471,2,352,2
+18,Sun,2023-01-08,4:25PM,Philadelphia Eagles,,New York Giants,boxscore,22,16,342,1,284,0
+18,Sun,2023-01-08,4:25PM,Seattle Seahawks,,Los Angeles Rams,boxscore,19,16,402,2,269,1
+18,Sun,2023-01-08,8:20PM,Detroit Lions,@,Green Bay Packers,boxscore,20,16,323,0,291,2

--- a/datasets/win-loss-score-2023-season.csv
+++ b/datasets/win-loss-score-2023-season.csv
@@ -1,0 +1,273 @@
+Week,Day,Date,Time,Winner/tie,,Loser/tie,,PtsW,PtsL,YdsW,TOW,YdsL,TOL
+1,Thu,2023-09-07,8:20PM,Detroit Lions,@,Kansas City Chiefs,boxscore,21,20,368,1,316,1
+1,Sun,2023-09-10,1:00PM,Atlanta Falcons,,Carolina Panthers,boxscore,24,10,221,0,281,3
+1,Sun,2023-09-10,1:00PM,Cleveland Browns,,Cincinnati Bengals,boxscore,24,3,350,2,142,0
+1,Sun,2023-09-10,1:00PM,Jacksonville Jaguars,@,Indianapolis Colts,boxscore,31,21,342,2,280,3
+1,Sun,2023-09-10,1:00PM,Washington Commanders,,Arizona Cardinals,boxscore,20,16,248,3,210,2
+1,Sun,2023-09-10,1:00PM,Baltimore Ravens,,Houston Texans,boxscore,25,9,265,2,268,1
+1,Sun,2023-09-10,1:00PM,Tampa Bay Buccaneers,@,Minnesota Vikings,boxscore,20,17,242,0,369,3
+1,Sun,2023-09-10,1:00PM,New Orleans Saints,,Tennessee Titans,boxscore,16,15,351,2,285,3
+1,Sun,2023-09-10,1:00PM,San Francisco 49ers,@,Pittsburgh Steelers,boxscore,30,7,391,1,239,2
+1,Sun,2023-09-10,4:25PM,Green Bay Packers,@,Chicago Bears,boxscore,38,20,329,0,311,2
+1,Sun,2023-09-10,4:25PM,Las Vegas Raiders,@,Denver Broncos,boxscore,17,16,261,1,260,0
+1,Sun,2023-09-10,4:25PM,Miami Dolphins,@,Los Angeles Chargers,boxscore,36,34,536,2,433,0
+1,Sun,2023-09-10,4:25PM,Philadelphia Eagles,@,New England Patriots,boxscore,25,20,251,1,382,2
+1,Sun,2023-09-10,4:25PM,Los Angeles Rams,@,Seattle Seahawks,boxscore,30,13,426,0,180,0
+1,Sun,2023-09-10,8:20PM,Dallas Cowboys,@,New York Giants,boxscore,40,0,265,0,171,3
+1,Mon,2023-09-11,8:15PM,New York Jets,,Buffalo Bills,boxscore,22,16,289,1,314,4
+2,Thu,2023-09-14,8:15PM,Philadelphia Eagles,,Minnesota Vikings,boxscore,34,28,430,1,374,4
+2,Sun,2023-09-17,1:00PM,Atlanta Falcons,,Green Bay Packers,boxscore,25,24,446,1,224,0
+2,Sun,2023-09-17,1:00PM,Buffalo Bills,,Las Vegas Raiders,boxscore,38,10,450,0,240,3
+2,Sun,2023-09-17,1:00PM,Tampa Bay Buccaneers,,Chicago Bears,boxscore,27,17,437,0,236,2
+2,Sun,2023-09-17,1:00PM,Baltimore Ravens,@,Cincinnati Bengals,boxscore,27,24,415,0,282,1
+2,Sun,2023-09-17,1:00PM,Indianapolis Colts,@,Houston Texans,boxscore,31,20,353,0,389,1
+2,Sun,2023-09-17,1:00PM,Seattle Seahawks,@,Detroit Lions,boxscore,37,31,393,0,418,3
+2,Sun,2023-09-17,1:00PM,Kansas City Chiefs,@,Jacksonville Jaguars,boxscore,17,9,399,3,271,1
+2,Sun,2023-09-17,1:00PM,Tennessee Titans,,Los Angeles Chargers,boxscore,27,24,341,0,342,0
+2,Sun,2023-09-17,4:05PM,New York Giants,@,Arizona Cardinals,boxscore,31,28,439,1,379,0
+2,Sun,2023-09-17,4:05PM,San Francisco 49ers,@,Los Angeles Rams,boxscore,30,23,365,0,386,2
+2,Sun,2023-09-17,4:25PM,Dallas Cowboys,,New York Jets,boxscore,30,10,382,0,215,4
+2,Sun,2023-09-17,4:25PM,Washington Commanders,@,Denver Broncos,boxscore,35,33,388,0,399,2
+2,Sun,2023-09-17,8:20PM,Miami Dolphins,@,New England Patriots,boxscore,24,17,389,1,288,2
+2,Mon,2023-09-18,7:15PM,New Orleans Saints,@,Carolina Panthers,boxscore,20,17,341,1,239,1
+2,Mon,2023-09-18,8:15PM,Pittsburgh Steelers,,Cleveland Browns,boxscore,26,22,255,2,408,4
+3,Thu,2023-09-21,8:15PM,San Francisco 49ers,,New York Giants,boxscore,30,12,441,0,150,1
+3,Sun,2023-09-24,1:00PM,Detroit Lions,,Atlanta Falcons,boxscore,20,6,358,1,183,1
+3,Sun,2023-09-24,1:00PM,Buffalo Bills,@,Washington Commanders,boxscore,37,3,386,1,230,5
+3,Sun,2023-09-24,1:00PM,Cleveland Browns,,Tennessee Titans,boxscore,27,3,341,1,94,0
+3,Sun,2023-09-24,1:00PM,Indianapolis Colts,@,Baltimore Ravens,boxscore,22,19,327,0,364,2
+3,Sun,2023-09-24,1:00PM,Miami Dolphins,,Denver Broncos,boxscore,70,20,726,0,363,3
+3,Sun,2023-09-24,1:00PM,Green Bay Packers,,New Orleans Saints,boxscore,18,17,340,1,252,0
+3,Sun,2023-09-24,1:00PM,Houston Texans,@,Jacksonville Jaguars,boxscore,37,17,366,0,404,2
+3,Sun,2023-09-24,1:00PM,Los Angeles Chargers,@,Minnesota Vikings,boxscore,28,24,475,1,475,2
+3,Sun,2023-09-24,1:00PM,New England Patriots,@,New York Jets,boxscore,15,10,358,0,171,0
+3,Sun,2023-09-24,4:05PM,Seattle Seahawks,,Carolina Panthers,boxscore,37,27,425,1,378,0
+3,Sun,2023-09-24,4:25PM,Kansas City Chiefs,,Chicago Bears,boxscore,41,10,456,2,203,2
+3,Sun,2023-09-24,4:25PM,Arizona Cardinals,,Dallas Cowboys,boxscore,28,16,400,0,416,1
+3,Sun,2023-09-24,8:20PM,Pittsburgh Steelers,@,Las Vegas Raiders,boxscore,23,18,333,0,362,3
+3,Mon,2023-09-25,7:15PM,Philadelphia Eagles,@,Tampa Bay Buccaneers,boxscore,25,11,472,2,174,2
+3,Mon,2023-09-25,8:15PM,Cincinnati Bengals,,Los Angeles Rams,boxscore,19,16,309,1,292,2
+4,Thu,2023-09-28,8:15PM,Detroit Lions,@,Green Bay Packers,boxscore,34,20,401,1,230,2
+4,Sun,2023-10-01,9:30AM,Jacksonville Jaguars,,Atlanta Falcons,boxscore,23,7,300,0,287,3
+4,Sun,2023-10-01,1:00PM,Buffalo Bills,,Miami Dolphins,boxscore,48,20,414,0,393,2
+4,Sun,2023-10-01,1:00PM,Minnesota Vikings,@,Carolina Panthers,boxscore,21,13,265,2,232,1
+4,Sun,2023-10-01,1:00PM,Denver Broncos,@,Chicago Bears,boxscore,31,28,311,0,471,2
+4,Sun,2023-10-01,1:00PM,Tennessee Titans,,Cincinnati Bengals,boxscore,27,3,400,1,211,1
+4,Sun,2023-10-01,1:00PM,Baltimore Ravens,@,Cleveland Browns,boxscore,28,3,296,1,166,3
+4,Sun,2023-10-01,1:00PM,Los Angeles Rams,@,Indianapolis Colts,boxscore,29,23,467,1,329,1
+4,Sun,2023-10-01,1:00PM,Houston Texans,,Pittsburgh Steelers,boxscore,30,6,451,0,225,1
+4,Sun,2023-10-01,1:00PM,Tampa Bay Buccaneers,@,New Orleans Saints,boxscore,26,9,353,1,197,3
+4,Sun,2023-10-01,1:00PM,Philadelphia Eagles,,Washington Commanders,boxscore,34,31,415,0,365,0
+4,Sun,2023-10-01,4:05PM,Los Angeles Chargers,,Las Vegas Raiders,boxscore,24,17,305,1,264,3
+4,Sun,2023-10-01,4:25PM,San Francisco 49ers,,Arizona Cardinals,boxscore,35,16,395,0,362,0
+4,Sun,2023-10-01,4:25PM,Dallas Cowboys,,New England Patriots,boxscore,38,3,377,0,253,3
+4,Sun,2023-10-01,8:20PM,Kansas City Chiefs,@,New York Jets,boxscore,23,20,401,2,336,1
+4,Mon,2023-10-02,8:15PM,Seattle Seahawks,@,New York Giants,boxscore,24,3,281,0,248,3
+5,Thu,2023-10-05,8:15PM,Chicago Bears,@,Washington Commanders,boxscore,40,20,451,0,388,2
+5,Sun,2023-10-08,9:30AM,Jacksonville Jaguars,@,Buffalo Bills,boxscore,25,20,474,2,388,2
+5,Sun,2023-10-08,1:00PM,Atlanta Falcons,,Houston Texans,boxscore,21,19,447,2,313,0
+5,Sun,2023-10-08,1:00PM,Detroit Lions,,Carolina Panthers,boxscore,42,24,377,0,342,3
+5,Sun,2023-10-08,1:00PM,Indianapolis Colts,,Tennessee Titans,boxscore,23,16,429,0,348,1
+5,Sun,2023-10-08,1:00PM,Miami Dolphins,,New York Giants,boxscore,31,16,524,3,268,0
+5,Sun,2023-10-08,1:00PM,New Orleans Saints,@,New England Patriots,boxscore,34,0,304,0,156,3
+5,Sun,2023-10-08,1:00PM,Pittsburgh Steelers,,Baltimore Ravens,boxscore,17,10,289,1,335,3
+5,Sun,2023-10-08,4:05PM,Cincinnati Bengals,@,Arizona Cardinals,boxscore,34,20,380,1,294,3
+5,Sun,2023-10-08,4:05PM,Philadelphia Eagles,@,Los Angeles Rams,boxscore,23,14,454,1,249,0
+5,Sun,2023-10-08,4:25PM,New York Jets,@,Denver Broncos,boxscore,31,21,407,2,308,3
+5,Sun,2023-10-08,4:25PM,Kansas City Chiefs,@,Minnesota Vikings,boxscore,27,20,333,0,329,1
+5,Sun,2023-10-08,8:20PM,San Francisco 49ers,,Dallas Cowboys,boxscore,42,10,421,1,197,4
+5,Mon,2023-10-09,8:15PM,Las Vegas Raiders,,Green Bay Packers,boxscore,17,13,279,1,285,3
+6,Thu,2023-10-12,8:15PM,Kansas City Chiefs,,Denver Broncos,boxscore,19,8,389,1,197,3
+6,Sun,2023-10-15,9:30AM,Baltimore Ravens,@,Tennessee Titans,boxscore,24,16,360,1,233,2
+6,Sun,2023-10-15,1:00PM,Cleveland Browns,,San Francisco 49ers,boxscore,19,17,334,2,215,1
+6,Sun,2023-10-15,1:00PM,Washington Commanders,@,Atlanta Falcons,boxscore,24,16,193,0,402,3
+6,Sun,2023-10-15,1:00PM,Miami Dolphins,,Carolina Panthers,boxscore,42,21,424,1,296,0
+6,Sun,2023-10-15,1:00PM,Minnesota Vikings,@,Chicago Bears,boxscore,19,13,220,1,275,3
+6,Sun,2023-10-15,1:00PM,Cincinnati Bengals,,Seattle Seahawks,boxscore,17,13,214,1,384,2
+6,Sun,2023-10-15,1:00PM,Jacksonville Jaguars,,Indianapolis Colts,boxscore,37,20,233,1,354,4
+6,Sun,2023-10-15,1:00PM,Houston Texans,,New Orleans Saints,boxscore,20,13,297,1,430,2
+6,Sun,2023-10-15,4:05PM,Las Vegas Raiders,,New England Patriots,boxscore,21,17,348,1,259,1
+6,Sun,2023-10-15,4:25PM,Los Angeles Rams,,Arizona Cardinals,boxscore,26,9,382,1,345,2
+6,Sun,2023-10-15,4:25PM,Detroit Lions,@,Tampa Bay Buccaneers,boxscore,20,6,380,0,251,1
+6,Sun,2023-10-15,4:25PM,New York Jets,,Philadelphia Eagles,boxscore,20,14,244,0,348,4
+6,Sun,2023-10-15,8:20PM,Buffalo Bills,,New York Giants,boxscore,14,9,297,2,317,0
+6,Mon,2023-10-16,8:15PM,Dallas Cowboys,@,Los Angeles Chargers,boxscore,20,17,342,1,272,1
+7,Thu,2023-10-19,8:15PM,Jacksonville Jaguars,@,New Orleans Saints,boxscore,31,24,330,2,407,1
+7,Sun,2023-10-22,1:00PM,Cleveland Browns,@,Indianapolis Colts,boxscore,39,38,316,2,456,4
+7,Sun,2023-10-22,1:00PM,Atlanta Falcons,@,Tampa Bay Buccaneers,boxscore,16,13,401,3,329,2
+7,Sun,2023-10-22,1:00PM,New England Patriots,,Buffalo Bills,boxscore,29,25,364,1,339,2
+7,Sun,2023-10-22,1:00PM,Chicago Bears,,Las Vegas Raiders,boxscore,30,12,323,0,235,3
+7,Sun,2023-10-22,1:00PM,Baltimore Ravens,,Detroit Lions,boxscore,38,6,503,1,337,1
+7,Sun,2023-10-22,1:00PM,New York Giants,,Washington Commanders,boxscore,14,7,356,2,273,1
+7,Sun,2023-10-22,4:05PM,Pittsburgh Steelers,@,Los Angeles Rams,boxscore,24,17,300,0,354,1
+7,Sun,2023-10-22,4:05PM,Seattle Seahawks,,Arizona Cardinals,boxscore,20,10,318,3,249,0
+7,Sun,2023-10-22,4:25PM,Denver Broncos,,Green Bay Packers,boxscore,19,17,339,0,331,1
+7,Sun,2023-10-22,4:25PM,Kansas City Chiefs,,Los Angeles Chargers,boxscore,31,17,483,2,358,2
+7,Sun,2023-10-22,8:20PM,Philadelphia Eagles,,Miami Dolphins,boxscore,31,17,355,2,244,1
+7,Mon,2023-10-23,8:15PM,Minnesota Vikings,,San Francisco 49ers,boxscore,22,17,452,1,325,3
+8,Thu,2023-10-26,8:15PM,Buffalo Bills,,Tampa Bay Buccaneers,boxscore,24,18,427,1,302,0
+8,Sun,2023-10-29,1:00PM,Carolina Panthers,,Houston Texans,boxscore,15,13,224,0,229,1
+8,Sun,2023-10-29,1:00PM,Dallas Cowboys,,Los Angeles Rams,boxscore,43,20,387,1,280,1
+8,Sun,2023-10-29,1:00PM,Minnesota Vikings,@,Green Bay Packers,boxscore,24,10,346,1,270,1
+8,Sun,2023-10-29,1:00PM,Tennessee Titans,,Atlanta Falcons,boxscore,28,23,375,1,342,1
+8,Sun,2023-10-29,1:00PM,New Orleans Saints,@,Indianapolis Colts,boxscore,38,27,511,1,371,1
+8,Sun,2023-10-29,1:00PM,Jacksonville Jaguars,@,Pittsburgh Steelers,boxscore,20,10,377,3,261,2
+8,Sun,2023-10-29,1:00PM,Miami Dolphins,,New England Patriots,boxscore,31,17,390,2,218,1
+8,Sun,2023-10-29,1:00PM,New York Jets,@,New York Giants,boxscore,13,10,251,2,194,0
+8,Sun,2023-10-29,1:00PM,Philadelphia Eagles,@,Washington Commanders,boxscore,38,31,374,2,472,1
+8,Sun,2023-10-29,4:05PM,Seattle Seahawks,,Cleveland Browns,boxscore,24,20,362,2,385,3
+8,Sun,2023-10-29,4:25PM,Cincinnati Bengals,@,San Francisco 49ers,boxscore,31,17,400,1,460,3
+8,Sun,2023-10-29,4:25PM,Baltimore Ravens,@,Arizona Cardinals,boxscore,31,24,268,0,310,2
+8,Sun,2023-10-29,4:25PM,Denver Broncos,,Kansas City Chiefs,boxscore,24,9,240,1,274,5
+8,Sun,2023-10-29,8:20PM,Los Angeles Chargers,,Chicago Bears,boxscore,30,13,352,1,295,2
+8,Mon,2023-10-30,8:15PM,Detroit Lions,,Las Vegas Raiders,boxscore,26,14,486,3,157,1
+9,Thu,2023-11-02,8:15PM,Pittsburgh Steelers,,Tennessee Titans,boxscore,20,16,326,0,340,1
+9,Sun,2023-11-05,9:30AM,Kansas City Chiefs,,Miami Dolphins,boxscore,21,14,267,1,292,1
+9,Sun,2023-11-05,1:00PM,Cleveland Browns,,Arizona Cardinals,boxscore,27,0,326,0,58,3
+9,Sun,2023-11-05,1:00PM,Green Bay Packers,,Los Angeles Rams,boxscore,20,3,391,2,187,2
+9,Sun,2023-11-05,1:00PM,Houston Texans,,Tampa Bay Buccaneers,boxscore,39,37,496,1,332,1
+9,Sun,2023-11-05,1:00PM,Minnesota Vikings,@,Atlanta Falcons,boxscore,31,28,363,2,370,2
+9,Sun,2023-11-05,1:00PM,New Orleans Saints,,Chicago Bears,boxscore,24,17,301,0,368,5
+9,Sun,2023-11-05,1:00PM,Washington Commanders,@,New England Patriots,boxscore,20,17,432,2,327,1
+9,Sun,2023-11-05,1:00PM,Baltimore Ravens,,Seattle Seahawks,boxscore,37,3,515,2,151,2
+9,Sun,2023-11-05,4:05PM,Indianapolis Colts,@,Carolina Panthers,boxscore,27,13,198,1,275,3
+9,Sun,2023-11-05,4:25PM,Philadelphia Eagles,,Dallas Cowboys,boxscore,28,23,292,0,406,1
+9,Sun,2023-11-05,4:25PM,Las Vegas Raiders,,New York Giants,boxscore,30,6,334,0,277,2
+9,Sun,2023-11-05,8:20PM,Cincinnati Bengals,,Buffalo Bills,boxscore,24,18,397,0,317,2
+9,Mon,2023-11-06,8:15PM,Los Angeles Chargers,@,New York Jets,boxscore,27,6,191,0,270,3
+10,Thu,2023-11-09,8:15PM,Chicago Bears,,Carolina Panthers,boxscore,16,13,295,0,213,0
+10,Sun,2023-11-12,9:30AM,Indianapolis Colts,@,New England Patriots,boxscore,10,6,264,1,340,2
+10,Sun,2023-11-12,1:00PM,Houston Texans,@,Cincinnati Bengals,boxscore,30,27,544,3,380,2
+10,Sun,2023-11-12,1:00PM,Cleveland Browns,@,Baltimore Ravens,boxscore,33,31,373,2,306,2
+10,Sun,2023-11-12,1:00PM,Pittsburgh Steelers,,Green Bay Packers,boxscore,23,19,324,0,399,2
+10,Sun,2023-11-12,1:00PM,San Francisco 49ers,@,Jacksonville Jaguars,boxscore,34,3,437,0,221,4
+10,Sun,2023-11-12,1:00PM,Tampa Bay Buccaneers,,Tennessee Titans,boxscore,20,6,340,1,209,1
+10,Sun,2023-11-12,1:00PM,Minnesota Vikings,,New Orleans Saints,boxscore,27,19,388,0,280,2
+10,Sun,2023-11-12,4:05PM,Detroit Lions,@,Los Angeles Chargers,boxscore,41,38,533,0,421,1
+10,Sun,2023-11-12,4:05PM,Arizona Cardinals,,Atlanta Falcons,boxscore,25,23,352,1,254,0
+10,Sun,2023-11-12,4:25PM,Dallas Cowboys,,New York Giants,boxscore,49,17,640,2,172,1
+10,Sun,2023-11-12,4:25PM,Seattle Seahawks,,Washington Commanders,boxscore,29,26,489,0,356,1
+10,Sun,2023-11-12,8:20PM,Las Vegas Raiders,,New York Jets,boxscore,16,12,274,2,365,1
+10,Mon,2023-11-13,8:15PM,Denver Broncos,@,Buffalo Bills,boxscore,24,22,300,1,369,4
+11,Thu,2023-11-16,8:15PM,Baltimore Ravens,,Cincinnati Bengals,boxscore,34,20,405,0,272,0
+11,Sun,2023-11-19,1:00PM,Dallas Cowboys,@,Carolina Panthers,boxscore,33,10,311,0,187,2
+11,Sun,2023-11-19,1:00PM,Cleveland Browns,,Pittsburgh Steelers,boxscore,13,10,259,1,249,0
+11,Sun,2023-11-19,1:00PM,Green Bay Packers,,Los Angeles Chargers,boxscore,23,20,397,0,394,1
+11,Sun,2023-11-19,1:00PM,Jacksonville Jaguars,,Tennessee Titans,boxscore,34,14,389,0,235,2
+11,Sun,2023-11-19,1:00PM,Miami Dolphins,,Las Vegas Raiders,boxscore,20,13,422,3,296,3
+11,Sun,2023-11-19,1:00PM,Detroit Lions,,Chicago Bears,boxscore,31,26,338,4,334,1
+11,Sun,2023-11-19,1:00PM,Houston Texans,,Arizona Cardinals,boxscore,21,16,419,3,319,2
+11,Sun,2023-11-19,1:00PM,New York Giants,@,Washington Commanders,boxscore,31,19,292,0,404,6
+11,Sun,2023-11-19,4:05PM,San Francisco 49ers,,Tampa Bay Buccaneers,boxscore,27,14,420,0,287,2
+11,Sun,2023-11-19,4:25PM,Los Angeles Rams,,Seattle Seahawks,boxscore,17,16,267,1,291,1
+11,Sun,2023-11-19,4:25PM,Buffalo Bills,,New York Jets,boxscore,32,6,393,1,155,4
+11,Sun,2023-11-19,8:20PM,Denver Broncos,,Minnesota Vikings,boxscore,21,20,295,0,385,3
+11,Mon,2023-11-20,8:15PM,Philadelphia Eagles,@,Kansas City Chiefs,boxscore,21,17,238,1,336,2
+12,Thu,2023-11-23,12:30PM,Green Bay Packers,@,Detroit Lions,boxscore,29,22,377,0,464,3
+12,Thu,2023-11-23,4:30PM,Dallas Cowboys,,Washington Commanders,boxscore,45,10,431,0,376,1
+12,Thu,2023-11-23,8:20PM,San Francisco 49ers,@,Seattle Seahawks,boxscore,31,13,377,1,220,2
+12,Fri,2023-11-24,3:00PM,Miami Dolphins,@,New York Jets,boxscore,34,13,395,3,159,2
+12,Sun,2023-11-26,1:00PM,Atlanta Falcons,,New Orleans Saints,boxscore,24,15,396,2,444,2
+12,Sun,2023-11-26,1:00PM,Tennessee Titans,,Carolina Panthers,boxscore,17,10,264,0,258,1
+12,Sun,2023-11-26,1:00PM,Pittsburgh Steelers,@,Cincinnati Bengals,boxscore,16,10,421,1,222,1
+12,Sun,2023-11-26,1:00PM,Indianapolis Colts,,Tampa Bay Buccaneers,boxscore,27,20,394,1,298,2
+12,Sun,2023-11-26,1:00PM,Jacksonville Jaguars,@,Houston Texans,boxscore,24,21,445,1,352,0
+12,Sun,2023-11-26,1:00PM,New York Giants,,New England Patriots,boxscore,10,7,220,1,283,3
+12,Sun,2023-11-26,4:05PM,Denver Broncos,,Cleveland Browns,boxscore,29,12,294,1,269,3
+12,Sun,2023-11-26,4:05PM,Los Angeles Rams,@,Arizona Cardinals,boxscore,37,14,457,1,292,0
+12,Sun,2023-11-26,4:25PM,Kansas City Chiefs,@,Las Vegas Raiders,boxscore,31,17,360,0,358,0
+12,Sun,2023-11-26,4:25PM,Philadelphia Eagles,,Buffalo Bills,boxscore,37,34,378,2,505,1
+12,Sun,2023-11-26,8:20PM,Baltimore Ravens,@,Los Angeles Chargers,boxscore,20,10,361,0,279,4
+12,Mon,2023-11-27,8:15PM,Chicago Bears,@,Minnesota Vikings,boxscore,12,10,317,2,242,4
+13,Thu,2023-11-30,8:15PM,Dallas Cowboys,,Seattle Seahawks,boxscore,41,35,411,0,406,1
+13,Sun,2023-12-03,1:00PM,Atlanta Falcons,@,New York Jets,boxscore,13,8,194,0,259,3
+13,Sun,2023-12-03,1:00PM,Indianapolis Colts,@,Tennessee Titans,boxscore,31,28,355,2,381,2
+13,Sun,2023-12-03,1:00PM,Houston Texans,,Denver Broncos,boxscore,22,17,353,0,282,3
+13,Sun,2023-12-03,1:00PM,Detroit Lions,@,New Orleans Saints,boxscore,33,28,347,0,362,2
+13,Sun,2023-12-03,1:00PM,Miami Dolphins,@,Washington Commanders,boxscore,45,15,406,0,245,1
+13,Sun,2023-12-03,1:00PM,Los Angeles Chargers,@,New England Patriots,boxscore,6,0,241,0,257,1
+13,Sun,2023-12-03,1:00PM,Arizona Cardinals,@,Pittsburgh Steelers,boxscore,24,10,282,0,317,1
+13,Sun,2023-12-03,4:05PM,Tampa Bay Buccaneers,,Carolina Panthers,boxscore,21,18,322,1,282,1
+13,Sun,2023-12-03,4:25PM,Los Angeles Rams,,Cleveland Browns,boxscore,36,19,399,0,327,1
+13,Sun,2023-12-03,4:25PM,San Francisco 49ers,@,Philadelphia Eagles,boxscore,42,19,456,0,333,0
+13,Sun,2023-12-03,8:20PM,Green Bay Packers,,Kansas City Chiefs,boxscore,27,19,382,0,337,1
+13,Mon,2023-12-04,8:15PM,Cincinnati Bengals,@,Jacksonville Jaguars,boxscore,34,31,491,1,376,0
+14,Thu,2023-12-07,8:15PM,New England Patriots,@,Pittsburgh Steelers,boxscore,21,18,303,1,264,1
+14,Sun,2023-12-10,1:00PM,Tampa Bay Buccaneers,@,Atlanta Falcons,boxscore,29,25,290,0,434,1
+14,Sun,2023-12-10,1:00PM,New Orleans Saints,,Carolina Panthers,boxscore,28,6,207,1,303,2
+14,Sun,2023-12-10,1:00PM,Chicago Bears,,Detroit Lions,boxscore,28,13,336,0,267,3
+14,Sun,2023-12-10,1:00PM,Cincinnati Bengals,,Indianapolis Colts,boxscore,34,14,385,1,272,2
+14,Sun,2023-12-10,1:00PM,Cleveland Browns,,Jacksonville Jaguars,boxscore,31,27,389,3,293,4
+14,Sun,2023-12-10,1:00PM,New York Jets,,Houston Texans,boxscore,30,6,347,1,135,0
+14,Sun,2023-12-10,1:00PM,Baltimore Ravens,,Los Angeles Rams,boxscore,37,31,449,1,410,0
+14,Sun,2023-12-10,4:05PM,Minnesota Vikings,@,Las Vegas Raiders,boxscore,3,0,231,0,202,3
+14,Sun,2023-12-10,4:05PM,San Francisco 49ers,,Seattle Seahawks,boxscore,28,16,527,2,324,2
+14,Sun,2023-12-10,4:25PM,Buffalo Bills,@,Kansas City Chiefs,boxscore,20,17,327,1,346,2
+14,Sun,2023-12-10,4:25PM,Denver Broncos,@,Los Angeles Chargers,boxscore,24,7,322,1,283,2
+14,Sun,2023-12-10,8:20PM,Dallas Cowboys,,Philadelphia Eagles,boxscore,33,13,394,1,324,3
+14,Mon,2023-12-11,8:15PM,New York Giants,,Green Bay Packers,boxscore,24,22,367,2,326,3
+14,Mon,2023-12-11,8:15PM,Tennessee Titans,@,Miami Dolphins,boxscore,28,27,403,3,366,1
+15,Thu,2023-12-14,8:15PM,Las Vegas Raiders,,Los Angeles Chargers,boxscore,63,21,378,0,326,5
+15,Sat,2023-12-16,1:00PM,Cincinnati Bengals,,Minnesota Vikings,boxscore,27,24,378,1,424,2
+15,Sat,2023-12-16,4:30PM,Indianapolis Colts,,Pittsburgh Steelers,boxscore,30,13,372,0,216,3
+15,Sat,2023-12-16,8:15PM,Detroit Lions,,Denver Broncos,boxscore,42,17,448,0,287,1
+15,Sun,2023-12-17,1:00PM,Carolina Panthers,,Atlanta Falcons,boxscore,9,7,283,0,204,2
+15,Sun,2023-12-17,1:00PM,Cleveland Browns,,Chicago Bears,boxscore,20,17,377,3,236,3
+15,Sun,2023-12-17,1:00PM,Tampa Bay Buccaneers,@,Green Bay Packers,boxscore,34,20,452,1,321,1
+15,Sun,2023-12-17,1:00PM,Houston Texans,@,Tennessee Titans,boxscore,19,16,340,1,204,1
+15,Sun,2023-12-17,1:00PM,Kansas City Chiefs,@,New England Patriots,boxscore,27,17,326,2,206,1
+15,Sun,2023-12-17,1:00PM,Miami Dolphins,,New York Jets,boxscore,30,0,290,0,103,4
+15,Sun,2023-12-17,1:00PM,New Orleans Saints,,New York Giants,boxscore,24,6,296,0,193,0
+15,Sun,2023-12-17,4:05PM,San Francisco 49ers,@,Arizona Cardinals,boxscore,45,29,406,0,436,2
+15,Sun,2023-12-17,4:05PM,Los Angeles Rams,,Washington Commanders,boxscore,28,20,445,2,297,1
+15,Sun,2023-12-17,4:25PM,Buffalo Bills,,Dallas Cowboys,boxscore,31,10,351,0,195,1
+15,Sun,2023-12-17,8:20PM,Baltimore Ravens,@,Jacksonville Jaguars,boxscore,23,7,396,1,333,2
+15,Mon,2023-12-18,8:15PM,Seattle Seahawks,,Philadelphia Eagles,boxscore,20,17,297,0,321,2
+16,Thu,2023-12-21,8:15PM,Los Angeles Rams,,New Orleans Saints,boxscore,30,22,458,0,339,1
+16,Sat,2023-12-23,4:30PM,Pittsburgh Steelers,,Cincinnati Bengals,boxscore,34,11,397,0,368,3
+16,Sat,2023-12-23,8:00PM,Buffalo Bills,@,Los Angeles Chargers,boxscore,24,22,335,3,273,0
+16,Sun,2023-12-24,1:00PM,Atlanta Falcons,,Indianapolis Colts,boxscore,29,10,406,0,262,1
+16,Sun,2023-12-24,1:00PM,Green Bay Packers,@,Carolina Panthers,boxscore,33,30,369,0,394,0
+16,Sun,2023-12-24,1:00PM,Cleveland Browns,@,Houston Texans,boxscore,36,22,418,2,250,2
+16,Sun,2023-12-24,1:00PM,Detroit Lions,@,Minnesota Vikings,boxscore,30,24,389,1,390,4
+16,Sun,2023-12-24,1:00PM,New York Jets,,Washington Commanders,boxscore,30,28,381,2,245,3
+16,Sun,2023-12-24,1:00PM,Seattle Seahawks,@,Tennessee Titans,boxscore,20,17,273,0,287,0
+16,Sun,2023-12-24,4:05PM,Tampa Bay Buccaneers,,Jacksonville Jaguars,boxscore,30,12,335,0,305,4
+16,Sun,2023-12-24,4:25PM,Chicago Bears,,Arizona Cardinals,boxscore,27,16,420,1,306,0
+16,Sun,2023-12-24,4:25PM,Miami Dolphins,,Dallas Cowboys,boxscore,22,20,375,0,339,1
+16,Sun,2023-12-24,8:15PM,New England Patriots,@,Denver Broncos,boxscore,26,23,289,1,276,2
+16,Mon,2023-12-25,1:00PM,Las Vegas Raiders,@,Kansas City Chiefs,boxscore,20,14,205,0,308,2
+16,Mon,2023-12-25,4:30PM,Philadelphia Eagles,,New York Giants,boxscore,33,25,465,2,292,1
+16,Mon,2023-12-25,8:15PM,Baltimore Ravens,@,San Francisco 49ers,boxscore,33,19,343,0,429,5
+17,Thu,2023-12-28,8:15PM,Cleveland Browns,,New York Jets,boxscore,37,20,428,3,360,2
+17,Sat,2023-12-30,8:15PM,Dallas Cowboys,,Detroit Lions,boxscore,20,19,384,2,420,2
+17,Sun,2023-12-31,1:00PM,Chicago Bears,,Atlanta Falcons,boxscore,37,17,432,0,307,4
+17,Sun,2023-12-31,1:00PM,Buffalo Bills,,New England Patriots,boxscore,27,21,281,1,294,4
+17,Sun,2023-12-31,1:00PM,Jacksonville Jaguars,,Carolina Panthers,boxscore,26,0,317,0,124,1
+17,Sun,2023-12-31,1:00PM,Indianapolis Colts,,Las Vegas Raiders,boxscore,23,20,349,0,370,0
+17,Sun,2023-12-31,1:00PM,Arizona Cardinals,@,Philadelphia Eagles,boxscore,35,31,449,1,275,1
+17,Sun,2023-12-31,1:00PM,Houston Texans,,Tennessee Titans,boxscore,26,3,312,0,187,1
+17,Sun,2023-12-31,1:00PM,Baltimore Ravens,,Miami Dolphins,boxscore,56,19,491,1,375,3
+17,Sun,2023-12-31,1:00PM,New Orleans Saints,@,Tampa Bay Buccaneers,boxscore,23,13,310,0,349,4
+17,Sun,2023-12-31,1:00PM,Los Angeles Rams,@,New York Giants,boxscore,26,25,391,3,389,1
+17,Sun,2023-12-31,1:00PM,San Francisco 49ers,@,Washington Commanders,boxscore,27,10,408,0,225,2
+17,Sun,2023-12-31,4:05PM,Pittsburgh Steelers,@,Seattle Seahawks,boxscore,30,23,468,0,369,1
+17,Sun,2023-12-31,4:25PM,Kansas City Chiefs,,Cincinnati Bengals,boxscore,25,17,373,1,263,0
+17,Sun,2023-12-31,4:25PM,Denver Broncos,,Los Angeles Chargers,boxscore,16,9,313,0,301,1
+17,Sun,2023-12-31,8:20PM,Green Bay Packers,@,Minnesota Vikings,boxscore,33,10,470,1,211,2
+18,Sat,2024-01-06,4:30PM,Pittsburgh Steelers,@,Baltimore Ravens,boxscore,17,10,289,2,224,2
+18,Sat,2024-01-06,8:15PM,Houston Texans,@,Indianapolis Colts,boxscore,23,19,306,0,360,1
+18,Sun,2024-01-07,1:00PM,New Orleans Saints,,Atlanta Falcons,boxscore,48,17,400,0,389,3
+18,Sun,2024-01-07,1:00PM,Tampa Bay Buccaneers,@,Carolina Panthers,boxscore,9,0,228,0,199,2
+18,Sun,2024-01-07,1:00PM,Cincinnati Bengals,,Cleveland Browns,boxscore,31,14,328,1,244,2
+18,Sun,2024-01-07,1:00PM,Detroit Lions,,Minnesota Vikings,boxscore,30,20,381,0,448,2
+18,Sun,2024-01-07,1:00PM,Tennessee Titans,,Jacksonville Jaguars,boxscore,28,20,327,1,362,2
+18,Sun,2024-01-07,1:00PM,New York Jets,@,New England Patriots,boxscore,17,3,254,1,119,2
+18,Sun,2024-01-07,4:25PM,Green Bay Packers,,Chicago Bears,boxscore,17,9,432,1,192,0
+18,Sun,2024-01-07,4:25PM,Seattle Seahawks,@,Arizona Cardinals,boxscore,21,20,327,0,466,0
+18,Sun,2024-01-07,4:25PM,Dallas Cowboys,@,Washington Commanders,boxscore,38,10,440,1,180,3
+18,Sun,2024-01-07,4:25PM,Las Vegas Raiders,,Denver Broncos,boxscore,27,14,359,0,286,1
+18,Sun,2024-01-07,4:25PM,Kansas City Chiefs,@,Los Angeles Chargers,boxscore,13,12,268,1,353,1
+18,Sun,2024-01-07,4:25PM,New York Giants,,Philadelphia Eagles,boxscore,27,10,415,1,299,4
+18,Sun,2024-01-07,4:25PM,Los Angeles Rams,@,San Francisco 49ers,boxscore,21,20,258,1,300,1
+18,Sun,2024-01-07,8:20PM,Buffalo Bills,@,Miami Dolphins,boxscore,21,14,473,3,275,2


### PR DESCRIPTION
This is credit to https://www.pro-football-reference.com/years/2022/games.htm - they have datasets that contain the information regarding the week, day, date, time, winner/tie, loser/tie, points winner had, turnovers the winner had, yards the loser had, and turnovers the loser had.